### PR TITLE
[S1APTester]: Support to send Authentication Failure message from S1APTester

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -205,7 +205,8 @@ typedef enum _ueMsgTypes
    UE_ESM_INFORMATION_RSP_TYPE,
    UE_EPS_DEACTIVATE_BER_REQ,
    UE_EPS_DEACTIVATE_BER_ACC,
-  UE_PDN_DISCONNECT_REQ_TYPE,
+   UE_PDN_DISCONNECT_REQ_TYPE,
+   UE_AUTH_FAILURE_TYPE
 }UeMsgTypes;
 
 typedef struct _ueEmmEpsAtchType
@@ -838,6 +839,13 @@ typedef struct _ueUetAuthRejInd
    U8 ueId;
 }UeUetAuthRejInd;
 
+typedef struct _ueUetAuthFailure
+{
+   U8 ueId;
+   U8 cause;
+   U8 auts[14];
+}UeUetAuthFailure;
+
 typedef struct _ueUetEmmStatus
 {
    U8 ueId;
@@ -912,6 +920,7 @@ typedef struct _uetMessage
      UeUetDeActvBearCtxtReq ueDeActvBerReq;
      UeUetDeActvBearCtxtAcc ueDeActvBerAcc;
      UeUetPdnDisconnectReq  ueUetPdnDisconnectReq;
+     UeUetAuthFailure         ueUetAuthFailure;
    }msg;
 }UetMessage;
 /* Ue Interface general Structure declerations */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -543,6 +543,37 @@ PUBLIC S16 handlAuthResp(ueAuthResp_t *data)
 }
 
 /*
+ *
+ *   Fun:   handlAuthFailure
+ *
+ *   Desc:  This function is used to handle Auth Failure
+ *          from Test Controller
+ *
+ *   Ret:   None
+ *
+ *   Notes: None
+ *
+ *   File:  fw_api_int.c
+ *
+ */
+PUBLIC S16 handlAuthFailure(ueAuthFailure_t *data)
+{
+   FwCb *fwCb = NULLP;
+   UetMessage *uetMsg = NULLP;
+   FW_GET_CB(fwCb);
+   FW_LOG_ENTERFN(fwCb);
+
+   FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+   uetMsg->msgType = UE_AUTH_FAILURE_TYPE;
+
+   uetMsg->msg.ueUetAuthFailure.ueId = data->ue_Id;
+   uetMsg->msg.ueUetAuthFailure.cause = data->cause;
+   cmMemcpy(uetMsg->msg.ueUetAuthFailure.auts, data->auts, TFW_AUTS_LEN);
+
+   fwSendToUeApp(uetMsg);
+   RETVALUE(ROK);
+}
+/*
  * 
  *   Fun:   handlRadCapUpd
  * 
@@ -2335,6 +2366,21 @@ PUBLIC S16 tfwApi
       {
          FW_LOG_DEBUG(fwCb, "UE_PDN_DISCONNECT_REQ");
          handlPdnDisconnectReq((uepdnDisconnectReq_t*)msg);
+         break;
+      }
+      case UE_AUTH_FAILURE:
+      {
+         FW_LOG_DEBUG(fwCb, "UE_AUTH_FAILURE");
+         if (fwCb->nbState == ENB_IS_UP)
+         {
+            handlAuthFailure((ueAuthFailure_t*)msg);
+         }  
+         else
+         {
+            FW_LOG_ERROR(fwCb, "FAILED TO SEND UE_AUTH_RESP: "\
+                  "ENBAPP IS NOT UP");
+            ret = RFAILED;
+         }
          break;
       }
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -100,6 +100,10 @@ extern "C" {
 #define UE_ESM_IP_SEC_SIZE 4
 #define UE_ESM_IPV6_FLOW_LABEL_SIZE  3
 #define UE_ESM_TFT_MAX_PARAM_BUF   10
+
+/* Authentication failure param AUTS length */
+#define TFW_AUTS_LEN         14
+
 #ifdef TFW_STUB /* definitions only required by test controller */
 
 /* Mobile Identity types */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -116,9 +116,10 @@ typedef enum {
    PATH_SW_REQ_ACK,
    ENB_CONFIGURATION_TRANSFER,
    MME_CONFIGURATION_TRANSFER = 81,
-  UE_PDN_DISCONNECT_REQ,
-  UE_PDN_DISCONNECT_TIMEOUT_IND,
-  UE_PDN_DISCONNECT_REJ
+   UE_PDN_DISCONNECT_REQ,
+   UE_PDN_DISCONNECT_TIMEOUT_IND,
+   UE_PDN_DISCONNECT_REJ,
+   UE_AUTH_FAILURE = 85
 }tfwCmd;
 
 typedef enum
@@ -1492,10 +1493,17 @@ typedef struct UeAuthRejInd
    U8 ue_Id;
 }ueAuthRejInd_t;
 
+typedef struct UeAuthFailure
+{
+   U8 ue_Id;
+   U8 cause;
+   U8 auts[TFW_AUTS_LEN];
+}ueAuthFailure_t;
+
 typedef struct UeEmmStatus
 {
    U8 ue_Id;
-   U8 cause;   
+   U8 cause;
 }ueEmmStatus_t;
 
 typedef struct UeEsmInformationReq


### PR DESCRIPTION
## Title
Support to send Authentication Failure message from s1ap simulator
## Summary
- Support to handle Authentication Failure message from python test script and sends message from s1aptester(UE) to MME.
-Background: 
As part of Magma issue PR#1022 identified that MME crashes when UE Authentication failure message received at MME. To simulate the scenario, added python test script at magma AGW and observed that there was no support to send the Authentication failure message from S1APTester. Hence added support to handle authentication failure message from python test script and sending to MME.

## Test plan
- Build sanity
- Newly added tests - test_attach_auth_failure.py
