### PR TITLE
Increased number of eNBs to 32 for multi enb testing

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_enb_db.h
+++ b/TestCntlrApp/src/enbApp/nb_enb_db.h
@@ -7,5 +7,5 @@
  */
 
 #define NB_ENB_DB_LINE_LEN    100
-#define NB_MAX_ENBS           5
+#define NB_MAX_ENBS           32
 #define NB_ENB_DB_MAX_ARGS    100

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -10,14 +10,14 @@
 /**********************************************************************
 
      Name:     S1SIM TFW API Interface
-  
+
      Type:     C header file
-  
+
      Desc:     This file contains the macros for Test Framework Interface.
 
      File:     fw_api_int.h
 
-     Prg:      
+     Prg:
 
 **********************************************************************/
 
@@ -81,7 +81,7 @@ extern "C" {
 #define MAX_APN_LENGTH                6
 #define MAX_LEN_PDN_ADDRESS          13
 #define MAX_LEN_ACCESS_PTNAME       100
-#define MAX_NUM_OF_ENBS             5
+#define MAX_NUM_OF_ENBS             32
 
 #define TFW_MAX_NUM_BPLMNS            5
 #define TFW_MAX_NUM_CSG_ID          256
@@ -95,7 +95,7 @@ extern "C" {
 #define TFW_MAX_GRPS_PER_MME        256
 #define TFW_MAX_CODES_PER_MME       256
 
-#define UE_ESM_IPV4_SIZE 4 
+#define UE_ESM_IPV4_SIZE 4
 #define UE_ESM_IPV6_SIZE 6
 #define UE_ESM_IP_SEC_SIZE 4
 #define UE_ESM_IPV6_FLOW_LABEL_SIZE  3


### PR DESCRIPTION
 Title: Modified code to support 32 eNBs 
Summary: Code is modified for testing more eNB and UEs.
The new test case is added in PR, https://github.com/facebookincubator/magma/pull/1077
Newly added tests:
test_multi_enb.py

