### PR TITLE
[Bug fix]Bug fix for changing assertTrue to assertEqual

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -848,11 +848,13 @@ typedef struct _ueUetEmmStatus
 typedef struct _ueUetEsmInformationReq
 {
    U8 ueId;
+   U8 tId;
 }UeUetEsmInformationReq;
 
 typedef struct _ueUetEsmInformationRsp
 {
    U8 ueId;
+   U8 tId;
    UeEmmNasPdnApn  nasPdnApn;
 }UeUetEsmInformationRsp;
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -3130,7 +3130,7 @@ PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
    insertUeCb(data->ue_Id, 0, 0, ueIdCb);
    uetMsg->msgType = UE_ESM_INFORMATION_RSP_TYPE;
    ueEsmInfoRsp = &uetMsg->msg.ueEsmInformationRsp;
-   ueEsmInfoRsp->ueId    = data->ue_Id;
+   ueEsmInfoRsp->ueId = data->ue_Id;
    ueEsmInfoRsp->tId = data->tId;
    if(data->pdnAPN_pr.pres == TRUE)
    {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -3131,6 +3131,7 @@ PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
    uetMsg->msgType = UE_ESM_INFORMATION_RSP_TYPE;
    ueEsmInfoRsp = &uetMsg->msg.ueEsmInformationRsp;
    ueEsmInfoRsp->ueId    = data->ue_Id;
+   ueEsmInfoRsp->tId     = data->tId;
    if(data->pdnAPN_pr.pres == TRUE)
    {
       ueEsmInfoRsp->nasPdnApn.len = data->pdnAPN_pr.len;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -3131,7 +3131,7 @@ PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
    uetMsg->msgType = UE_ESM_INFORMATION_RSP_TYPE;
    ueEsmInfoRsp = &uetMsg->msg.ueEsmInformationRsp;
    ueEsmInfoRsp->ueId    = data->ue_Id;
-   ueEsmInfoRsp->tId     = data->tId;
+   ueEsmInfoRsp->tId = data->tId;
    if(data->pdnAPN_pr.pres == TRUE)
    {
       ueEsmInfoRsp->nasPdnApn.len = data->pdnAPN_pr.len;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -1501,11 +1501,13 @@ typedef struct UeEmmStatus
 typedef struct UeEsmInformationReq
 {
    U8 ue_Id;
+   U8 tId;
 }ueEsmInformationReq_t;
 
 typedef struct UeEsmInformationRsp
 {
    U8 ue_Id;
+   U8 tId;
    pdn_APN  pdnAPN_pr;
 }ueEsmInformationRsp_t;
 typedef struct multiEnbCfgParam

--- a/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
+++ b/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
@@ -2045,6 +2045,7 @@ PUBLIC S16 sendUeEsmInformationReqToTstCntlr
    FW_ALLOC_MEM(fwCb, &tfwEsmInformationReq , sizeof(ueEsmInformationReq_t));
 
    tfwEsmInformationReq->ue_Id = ueEsmInfoReq->msg.ueEsmInformationReq.ueId;
+   tfwEsmInformationReq->tId = ueEsmInfoReq->msg.ueEsmInformationReq.tId;
    (fwCb->testConrollerCallBack)(UE_ESM_INFORMATION_REQ, tfwEsmInformationReq, 
          sizeof(ueEsmInformationReq_t));
 

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1841,6 +1841,10 @@ PRIVATE S16 ueAppEsmHdlOutUeEvnt(CmNasEvnt *evnt, UeCb *ueCb)
        /*esmMsg->bearerId = 6;*/
       ret = ueAppUtlFndEsmCb(&esmCb, esmMsg->bearerId, UE_ESM_BID_KEY, ueCb);
    }
+   else if (esmMsg->msgType == CM_ESM_MSG_ESM_INFO_RSP)
+   {
+     ret = ueAppUtlFndEsmCb(&esmCb, esmMsg->prTxnId, UE_ESM_TRANS_KEY, ueCb);
+   }
    else
    {
       ret = ueAppUtlAddEsmCb(&esmCb, ueCb);
@@ -6970,8 +6974,9 @@ PRIVATE S16 ueAppEsmHndlIncEsmInfoReq
    esmCb->pState = UE_ESM_ST_PROC_TXN_INACTIVE;
    /* send ESM Information Indication to user */
    tfwMsg = (UetMessage*)ueAlloc(sizeof(UetMessage));
-   tfwMsg->msg.ueEsmInformationReq.ueId                        = ueCb->ueId;
+   tfwMsg->msg.ueEsmInformationReq.ueId = ueCb->ueId;
    tfwMsg->msgType = UE_ESM_INFORMATION_REQ_TYPE;
+   tfwMsg->msg.ueEsmInformationReq.tId = evnt->m.esmEvnt->prTxnId;
    ret = ueSendToTfwApp(tfwMsg, &ueAppCb->fwPst); 
    if (ret != ROK)
    {
@@ -8988,6 +8993,7 @@ PRIVATE S16 ueAppUtlBldEsmInformationRsp
    /*Fill mandatory IE's*/
    /* EPS barer ID IE*/
    msg->bearerId = 0;
+   msg->prTxnId = ueEsmInformationRsp->tId;
 
    /* PDN connectivity request message idenmtity*/
    msg->msgType = CM_ESM_MSG_ESM_INFO_RSP;


### PR DESCRIPTION
## Title
Bug fix to send valid PTI in ESM information response message

## Summary
ESM information response was sent with wrong Procedure Transaction Identity(PTI) due to which MME was sending STATUS message with cause "invalid PTI". This PR fixes the bug

## Test plan
1.Executed S1 SIM sanity
2.Executed test_attach_esm_information.py and test_attach_esm_information_wrong_apn.py TCs
