### PR TITLE
Rsarwad fix for plmn length

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -679,7 +679,7 @@ NbConfigReq   *cfg
    U16 smEvent;
    U32 plmnVal;
    U8  plmnLen;
-   U8  tmpPlmn[NB_THREE];
+   U8  tmpPlmn[NB_THREE] = {0};
    SztPLMNidentity pLMNidentity;
 
    NB_LOG_ENTERFN(&nbCb);

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -8,17 +8,17 @@
 
 /**********************************************************************
 
-    Name:  LTE S1SIM - ENODEB Application Module 
+    Name:  LTE S1SIM - ENODEB Application Module
 
     Type:  C include file
-               
+
     Desc:  C source code for ENODEB Application
 
      File:     nb.c
 
-    Sid:   
+    Sid:
 
-     Prg:      
+     Prg:
 
 **********************************************************************/
 
@@ -58,7 +58,7 @@ EXTERN S16 nbAppRouteInit(U32 selfIp, S8*);
 
 EXTERN NbDamCb nbDamCb;
 
-/* @brief This function updates the MME control Block with 
+/* @brief This function updates the MME control Block with
  *       GUMMEIs received in S1 Setup response message.
  *
  * @details This function updates the MME control Block with
@@ -67,12 +67,12 @@ EXTERN NbDamCb nbDamCb;
  * Function: nbEmmMmePrcGummeis
  *
  *       Processing steps:
- *        - 
+ *        -
  *
- *       - Notes: We support only LTE PLMN IDs and hence we process 
+ *       - Notes: We support only LTE PLMN IDs and hence we process
  *           only one IE in this function.
  *
- *@param[in, out] mmeCb: MME control block. 
+ *@param[in, out] mmeCb: MME control block.
  * @param[in]         ie: served GUMME IDs IE receved in
  *                      S1-Setup Response msg.
  *@return  S16
@@ -116,7 +116,7 @@ PRIVATE S16 nbMmePrcGummeis
 
    for(idx = 0; idx < noGrpIds; idx++)
    {
-      mmeCb->groupIds[idx] = (((grpIds->member + idx)->val[1]) | 
+      mmeCb->groupIds[idx] = (((grpIds->member + idx)->val[1]) |
             ((grpIds->member + idx)->val[0] << 8));
    }
 
@@ -138,12 +138,12 @@ PRIVATE S16 nbMmePrcGummeis
    RETVALUE(ROK);
 
 }
- 
+
 /*
  *         Fun:     nbHandleS1SetupReq
  *
  *  Desc:    This primitive is called by SM to request
- *            EMM to invoke S1 Setup with the configured 
+ *            EMM to invoke S1 Setup with the configured
  *             MMEs.
  *
  *  Ret:     ROK   - OK / RFAILED - Failure
@@ -166,7 +166,7 @@ PUBLIC S16 nbHandleS1SetupReq
  *
  * @details This function process the S1AP:S1 Setup Response mesage.
  *
- *Function: wrEmmMmePrcSetupRsp 
+ *Function: wrEmmMmePrcSetupRsp
  *
  * Processing steps:
  *  - Stop the S1 Setup Response timer.
@@ -178,7 +178,7 @@ PUBLIC S16 nbHandleS1SetupReq
  *          successfully.
  *
  *@param[in]     peerId: Peer Id from which S1 setup resp recvd
- *@param[in]        pdu: S1-AP:setup response PDU 
+ *@param[in]        pdu: S1-AP:setup response PDU
  *@return  S16
  *          -# Success : ROK
  *         -# Failure : RFAILED
@@ -335,14 +335,14 @@ PUBLIC S16 nbPrcResetAck
  * @brief This function constructs the PLMN ID from the received S1AP PLMN IE.
  *
  * @details This function constructs the PLMN ID from the received S1AP PLMN IE.
- * 
+ *
  * Function: nbParsePlmnIe
- * 
+ *
  * Processing steps:
- *        - 
- * 
- * 
- * @param[in]   plmnIe: S1-AP PLMN IE  
+ *        -
+ *
+ *
+ * @param[in]   plmnIe: S1-AP PLMN IE
  * @param[out]  plmnId: PLMN ID
  * @return  S16
  *          -# Success : ROK
@@ -372,7 +372,7 @@ PUBLIC Void  nbParsePlmnIe
       plmnId->mnc[2]       = (plmnIe->val[2] & 0xf0) >> 4;
    }
   /* RETVALUE(ROK);*/
-} 
+}
 
 PUBLIC Void nbAddPlmnId
 (
@@ -431,7 +431,7 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId)
    NbUeTunInfo    *tunInfo = NULLP;
 
    NB_LOG_ENTERFN(&nbCb);
-   #if 0 
+   #if 0
    for(idx = 0; nbCb.ueCbLst[idx] != NULLP ; idx++)
    {
       if(nbCb.ueCbLst[idx]->ueId == ueId)
@@ -457,9 +457,9 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId)
 #else
             if ( ROK != (cmHashListFind(&(ueCb->tunnInfo), (U8 *)&(berId),
                         sizeof(U32),0,(PTR *)&tunInfo)))
-            {    
+            {
                RETVALUE(RFAILED);
-            }    
+            }
 #endif
             else
             {
@@ -494,12 +494,12 @@ PUBLIC S16 nbDelUeCb(U8 ueId)
       {
          ueCb = nbCb.ueCbLst[idx];
          /* delete the tunninfo cb */
-#if 0 
+#if 0
          NB_FREE(ueCb->tunnInfo,sizeof(NbUeTunInfo));
 #endif
          /* delete the s1apcb */
          NB_FREE(ueCb->s1ConCb,sizeof(NbS1ConCb));
-         /* delete the ueCb */ 
+         /* delete the ueCb */
          NB_FREE(ueCb,sizeof(NbUeCb));
          nbCb.ueCbLst[idx] = NULLP;
          ret = ROK;
@@ -522,21 +522,21 @@ PUBLIC S16 nbDelUeCb(U8 ueId)
 #endif
       /* delete the s1apcb */
       NB_FREE(ueCb->s1ConCb,sizeof(NbS1ConCb));
-      /* delete the ueCb */ 
+      /* delete the ueCb */
       for(;((cmHashListGetNext(&(ueCb->tunnInfo),(PTR)prevTunnCb,(PTR*)&tunnCb)) == ROK);)
-      { 
+      {
          if(ueCb->tunnIdx == 0)
-            break; 
+            break;
          ret  = cmHashListDelete(&(ueCb->tunnInfo), (PTR)tunnCb);
          if (ret == RFAILED)
          {
             NB_LOG_ERROR(&nbCb,"Failed to delete TunnelCb");
-            
+
          }
          NB_FREE(tunnCb, sizeof(NbUeTunInfo))
          tunnCb = NULLP;
          ueCb->tunnIdx--;
-      }   
+      }
       cmHashListDeinit(&(ueCb->tunnInfo));
       cmHashListDelete(&(nbCb.ueCbLst), (PTR)ueCb);
       NB_FREE(ueCb,sizeof(NbUeCb));
@@ -544,9 +544,9 @@ PUBLIC S16 nbDelUeCb(U8 ueId)
       NB_LOG_DEBUG(&nbCb,"UE context successfully deleted with ueId:[%d]",
                ueId);
    }
-   nbRelCntxtInTrafficHandler(ueId); 
+   nbRelCntxtInTrafficHandler(ueId);
    /* - Inform the Tfw about UE context release
-      - When the ue release is local release i.e 
+      - When the ue release is local release i.e
          occurred due to sctp shutdown/abort, need not to inform Stub
       - Release indication will be sent to Stub in only in case of
          when MME is Sending UE_CNTXT Release Command
@@ -580,10 +580,10 @@ PUBLIC Void nbHandleUeDelReq(NbUeCb *ueCb)
       }
 
    }   /* trigger req to delete the s1ap connection cb */
-   RETVOID; 
+   RETVOID;
 }
 
-/** @brief This function is responsible for sending context release request 
+/** @brief This function is responsible for sending context release request
  *
  * @details
  *
@@ -635,7 +635,7 @@ PUBLIC S16 nbSndCtxtRelReq
       RETVALUE(RFAILED);
    }
    /* Check for s1ConCb before sending Connection release to MME */
-   if(NULLP != ueCb->s1ConCb) 
+   if(NULLP != ueCb->s1ConCb)
    {
             NB_LOG_DEBUG(&nbCb,"Sending UE CONTEXT RELEASE REQUEST" \
             ",MME-UE-S1AP-ID[%d], eNB-UE-S1AP-ID[%d]",\
@@ -660,17 +660,17 @@ PUBLIC S16 nbSndCtxtRelReq
    RETVALUE(ROK);
 }
 
-/* 
+/*
  *@details This function is used Porocess the Received enbApp config req
  *
- *Function:NbUiNbtEnbCfgReq 
+ *Function:NbUiNbtEnbCfgReq
  *
- * @param[in] NbConfigReq *cfg 
+ * @param[in] NbConfigReq *cfg
  * @return  S16
  *  -# Success : ROK
  *   -# Failure : RFAILED
  */
-PUBLIC S16 NbEnbCfgReqHdl 
+PUBLIC S16 NbEnbCfgReqHdl
 (
 NbConfigReq   *cfg
 )
@@ -698,15 +698,15 @@ NbConfigReq   *cfg
       RETVALUE(ROK);
    }
 
-   /* populate the stack manager structure and trigger the stack 
+   /* populate the stack manager structure and trigger the stack
     * initialization */
-   smCfgCb.cellId              = cfg->cellId; 
+   smCfgCb.cellId              = cfg->cellId;
    smCfgCb.trackAreaCode       = cfg->tac;
    smCfgCb.enbIpAddr           = cfg->enbIpAddr;
    cmMemset(smCfgCb.enbName,0,NB_ENB_NAME);
    if(strlen((S8*)cfg->enbName) < NB_ENB_NAME)
    {
-      cmMemcpy(smCfgCb.enbName,cfg->enbName,strlen((S8*)cfg->enbName)); 
+      cmMemcpy(smCfgCb.enbName,cfg->enbName,strlen((S8*)cfg->enbName));
       smCfgCb.enbNameLen            = strlen((S8*)cfg->enbName);
    }
    smCfgCb.sctpIpAddr          = cfg->sctpIpAddr;
@@ -780,20 +780,20 @@ NbConfigReq   *cfg
    smCfgCb.smState               = NB_SM_STATE_INIT;
    smCfgCb.noOfCfg               = NB_ONE; /* no of mme */
    NB_ALLOC(&smCfgCb.mmeCfg[0], sizeof(LnbSmMmeCfg));
-   smCfgCb.mmeCfg[0]->mmeId      = cfg->mmeId; 
+   smCfgCb.mmeCfg[0]->mmeId      = cfg->mmeId;
    smCfgCb.mmeCfg[0]->noOfIps    = NB_ONE; /* no. of ip per mme */
-   smCfgCb.mmeCfg[0]->mmeAddr[0] = cfg->mmeAddr; 
+   smCfgCb.mmeCfg[0]->mmeAddr[0] = cfg->mmeAddr;
    smCfgCb.noOfSctpInStreams     = cfg->noOfSctpInStreams;
    smCfgCb.noOfSctpOutStreams    = cfg->noOfSctpOutStreams;
 #ifdef MULTI_ENB_SUPPORT
    smCfgCb.numOfEnbs             = cfg->numOfEnbs;
 #endif
-   
+
 
    if(nbAppRouteInit(smCfgCb.enbIpAddr, cfg->ueEthIntf) != ROK)
    {
       NB_LOG_ERROR(&nbCb,"Failed to initialize Pcap");
-      nbUiSendConfigFailIndToUser(NB_PCAP_CFG_FAILED);  
+      nbUiSendConfigFailIndToUser(NB_PCAP_CFG_FAILED);
       smCfgCb.smState   = NB_SM_STATE_INIT;
       RETVALUE(RFAILED);
    }
@@ -803,18 +803,18 @@ NbConfigReq   *cfg
    RETVALUE(ROK);
 }
 
-/* 
- * @details This function is used Process the Received UE context 
+/*
+ * @details This function is used Process the Received UE context
  *          Release Request from TFW.
  *
  * Function: NbEnbUeRelReqHdl
  *
- * @param[in] NbUeCntxtRelReq *relReq 
+ * @param[in] NbUeCntxtRelReq *relReq
  * @return  S16
  *  -# Success : ROK
  *  -# Failure : RFAILED
  */
-PUBLIC S16 NbEnbUeRelReqHdl 
+PUBLIC S16 NbEnbUeRelReqHdl
 (
  NbUeCntxtRelReq *relReq
 )
@@ -858,7 +858,7 @@ PRIVATE S16 getS1apInfoFrmUeId
 
    for(cnt = 0; cnt < numOfUes; cnt++)
    {
-      ueId = ueIdLst[cnt]; 
+      ueId = ueIdLst[cnt];
       if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
       sizeof(U8),0,(PTR *)&ueCb)))
       {
@@ -871,7 +871,7 @@ PRIVATE S16 getS1apInfoFrmUeId
    RETVALUE(ROK);
 } /* getS1apInfoFrmUeId */
 
-PUBLIC S16 NbEnbResetReqHdl 
+PUBLIC S16 NbEnbResetReqHdl
 (
  NbResetRequest *resetReq
 )
@@ -913,7 +913,7 @@ PUBLIC S16 NbEnbResetReqHdl
          NB_LOG_ERROR(&nbCb, "Failed to send UE Delete Indication to DAM");
          RETVALUE(RFAILED);
         }
-      } 
+      }
       NB_FREE(resetReq->u.partialRst.ueIdLst, resetReq->u.partialRst.numOfConn);
    }
    else
@@ -957,8 +957,8 @@ PUBLIC S16 NbEnbResetReqHdl
    RETVALUE(ROK);
 } /* NbEnbResetReqHdl */
 
-PUBLIC S16 NbEnbErabRelIndHdl 
-( 
+PUBLIC S16 NbEnbErabRelIndHdl
+(
  NbuErabRelIndList *erabRelInd
 )
 {
@@ -997,8 +997,8 @@ PUBLIC S16 NbEnbErabRelIndHdl
    RETVALUE(ROK);
 } /* NbEnbErabRelIndHdl */
 
-PUBLIC S16 NbEnbErabRelRspHdl 
-( 
+PUBLIC S16 NbEnbErabRelRspHdl
+(
  NbErabRelRsp *erabRelRsp
 )
 {
@@ -1051,8 +1051,8 @@ PUBLIC S16 NbEnbErabRelRspHdl
    RETVALUE(ROK);
 } /* NbEnbErabRelRspHdl */
 
-PUBLIC S16 NbEnbNasNonDel 
-( 
+PUBLIC S16 NbEnbNasNonDel
+(
  NbNasNonDel *nasNonDel
 )
 {
@@ -1068,7 +1068,7 @@ PUBLIC S16 NbEnbNasNonDel
    nbCb.nasNonDel[(nasNonDel->ueId) - 1].causeType = nasNonDel->causeType;
    nbCb.nasNonDel[(nasNonDel->ueId) - 1].causeVal = nasNonDel->causeVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail)
 {
@@ -1084,16 +1084,16 @@ PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail)
    nbCb.initCtxtSetupFail[(initCtxtSetupFail->ueId) - 1].causeType = initCtxtSetupFail->causeType;
    nbCb.initCtxtSetupFail[(initCtxtSetupFail->ueId) - 1].causeVal = initCtxtSetupFail->causeVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 
 /*
  * @details This function marked a ue for dropping intial context setup
- * 
- * Function: NbEnbDropInitCtxtSetup 
- * 
- * 
- * @param[in]  NbDropInitCtxtSetup 
+ *
+ * Function: NbEnbDropInitCtxtSetup
+ *
+ *
+ * @param[in]  NbDropInitCtxtSetup
  * @return  S16
  *          -# Success : ROK
  */
@@ -1110,16 +1110,16 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup)
    nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable = dropInitCtxtSetup->isDropICSEnable;
    nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].tmrVal = dropInitCtxtSetup->tmrVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 
 /*
  * @details This function marked a ue for delay intial context setup
- * 
- * Function: NbEnbDelayInitCtxtSetup 
- * 
- * 
- * @param[in]  NbDelayInitCtxtSetup 
+ *
+ * Function: NbEnbDelayInitCtxtSetup
+ *
+ *
+ * @param[in]  NbDelayInitCtxtSetup
  * @return  S16
  *          -# Success : ROK
  */
@@ -1136,15 +1136,15 @@ PUBLIC S16 NbEnbDelayInitCtxtSetupRsp(NbDelayICSRsp *delayICSRsp)
    nbCb.delayInitCtxtSetupRsp[(delayICSRsp->ueId) - 1].delayICSRsp  = delayICSRsp->isDelayICSRsp;
    nbCb.delayInitCtxtSetupRsp[(delayICSRsp->ueId) - 1].tmrVal  = delayICSRsp->tmrVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 /*
- * @details This function marked a ue for delay ue context release complete 
- * 
+ * @details This function marked a ue for delay ue context release complete
+ *
  * Function: NbEnbDelayUeCtxtRelCmp
- * 
- * 
- * @param[in]  NbDelayUeCtxtRelCmp 
+ *
+ *
+ * @param[in]  NbDelayUeCtxtRelCmp
  * @return  S16
  *          -# Success : ROK
  */
@@ -1160,16 +1160,16 @@ PUBLIC S16 NbEnbDelayUeCtxtRelCmp(NbDelayUeCtxtRelCmp *delayUeCRC)
    nbCb.delayUeCtxtRelCmp[(delayUeCRC->ueId) - 1].delayUeCtxRelComp  = delayUeCRC->isDelayUeCtxtRelCmp;
    nbCb.delayUeCtxtRelCmp[(delayUeCRC->ueId) - 1].tmrVal  = delayUeCRC->tmrVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 /*
  * @details This function marked a ue for dropping intial context setup and
  * sending ue context release message
- * 
- * Function: NbEnbUeCtxtRelForInitCtxtSetup 
- * 
- * 
- * @param[in]  NbDropInitCtxtSetup 
+ *
+ * Function: NbEnbUeCtxtRelForInitCtxtSetup
+ *
+ *
+ * @param[in]  NbDropInitCtxtSetup
  * @return  S16
  *          -# Success : ROK
  */
@@ -1187,7 +1187,7 @@ PUBLIC S16 NbEnbUeCtxtRelForInitCtxtSetup(NbSendUeCtxtRelForICSRsp *sendUeCtxtRe
    nbCb.dropICSSndCtxtRel[(sendUeCtxtRelReq->ueId) - 1].causeType = sendUeCtxtRelReq->causeType;
    nbCb.dropICSSndCtxtRel[(sendUeCtxtRelReq->ueId) - 1].causeVal = sendUeCtxtRelReq->causeVal;
 
-   RETVALUE(ROK); 
+   RETVALUE(ROK);
 }
 
 PUBLIC S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq *multiEnbCfgReq)
@@ -1204,53 +1204,61 @@ PUBLIC S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq *multiEnbCfgReq)
       NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
       RETVALUE(RFAILED);
    }
-   nbCb.multiEnbCfgInfo.pres  = TRUE; 
+   nbCb.multiEnbCfgInfo.pres  = TRUE;
    nbCb.multiEnbCfgInfo.numOfEnbs = multiEnbCfgReq->numOfEnbs;
-   for (int index = 0; index < multiEnbCfgReq->numOfEnbs;index++) 
-   {
-      /* Allocate memory */
-      NB_ALLOC(&eNbCb, sizeof(EnbCb));
-      eNbCb->enbId   = index;
-      eNbCb->cell_id = multiEnbCfgReq->nbMultiEnbCfgParam[index].cell_id ;
-      eNbCb->tac     = multiEnbCfgReq->nbMultiEnbCfgParam[index].tac;
-      eNbCb->enbType = multiEnbCfgReq->nbMultiEnbCfgParam[index].enbType;
+   for (int index = 0; index < multiEnbCfgReq->numOfEnbs; index++) {
+     /* Allocate memory */
+     NB_ALLOC(&eNbCb, sizeof(EnbCb));
+     eNbCb->enbId = index;
+     eNbCb->cell_id = multiEnbCfgReq->nbMultiEnbCfgParam[index].cell_id;
+     eNbCb->tac = multiEnbCfgReq->nbMultiEnbCfgParam[index].tac;
+     eNbCb->enbType = multiEnbCfgReq->nbMultiEnbCfgParam[index].enbType;
+     eNbCb->plmn_length = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_length;
 
-      if (multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[5] == 0) {
-         eNbCb->plmnId.numMncDigits = 2;
-      } else {
-         eNbCb->plmnId.numMncDigits = 3;
-      }
-      eNbCb->plmnId.numMncDigits = 2;
-      eNbCb->plmnId.mcc[0] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[0];
-      eNbCb->plmnId.mcc[1] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[1];
-      eNbCb->plmnId.mcc[2] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[2];
-      eNbCb->plmnId.mnc[0] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[3];
-      eNbCb->plmnId.mnc[1] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[4];
-      eNbCb->plmnId.mnc[2] = multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[5];
-      NB_LOG_DEBUG(&nbCb, "Inserting EnbCb into the ENB list for enbId = %d", eNbCb->enbId);
-      if (ROK != cmHashListInsert(&(nbCb.eNBCbLst),(PTR)eNbCb,
-           		   (U32 *) &eNbCb->enbId,sizeof(U32)))
-      {
-         NB_FREE(eNbCb, sizeof(EnbCb))
-         NB_LOG_ERROR(&nbCb, "Failed to Insert ENB into eNBCbLst[%d]",eNbCb->enbId);
-         RETVALUE(RFAILED);
-      }
-   }  
-   RETVALUE(ROK); 
+     if (eNbCb->plmn_length == 5) {
+       eNbCb->plmnId.numMncDigits = 2;
+     } else {
+       eNbCb->plmnId.numMncDigits = 3;
+     }
+     eNbCb->plmnId.mcc[0] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[0];
+     eNbCb->plmnId.mcc[1] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[1];
+     eNbCb->plmnId.mcc[2] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[2];
+     eNbCb->plmnId.mnc[0] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[3];
+     eNbCb->plmnId.mnc[1] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[4];
+     eNbCb->plmnId.mnc[2] =
+       multiEnbCfgReq->nbMultiEnbCfgParam[index].plmn_id[5];
+     NB_LOG_DEBUG(
+       &nbCb, "Inserting EnbCb into the ENB list for enbId = %d", eNbCb->enbId);
+     if (
+       ROK !=
+       cmHashListInsert(
+         &(nbCb.eNBCbLst), (PTR) eNbCb, (U32*) &eNbCb->enbId, sizeof(U32))) {
+       NB_FREE(eNbCb, sizeof(EnbCb))
+       NB_LOG_ERROR(
+         &nbCb, "Failed to Insert ENB into eNBCbLst[%d]", eNbCb->enbId);
+       RETVALUE(RFAILED);
+     }
+   }
+   RETVALUE(ROK);
 }
 #ifdef MULTI_ENB_SUPPORT
-/* 
- * @details This function is used Process the Received X2 HO 
+/*
+ * @details This function is used Process the Received X2 HO
  *          Trigger Request from TFW.
  *
- * Function: NbEnbX2HOTriggerReqHdl  
+ * Function: NbEnbX2HOTriggerReqHdl
  *
- * @param[in] NbUeCntxtRelReq *relReq 
+ * @param[in] NbUeCntxtRelReq *relReq
  * @return  S16
  *  -# Success : ROK
  *  -# Failure : RFAILED
  */
-PUBLIC S16 NbEnbX2HOTriggerReqHdl 
+PUBLIC S16 NbEnbX2HOTriggerReqHdl
 (
  NbX2HOTriggerReq *x2HOTriggerReq
 )
@@ -1310,12 +1318,12 @@ PUBLIC S16 NbEnbX2HOTriggerReqHdl
    for(;((cmHashListGetNext(&(ueCb->tunnInfo),(PTR)prevTunnCb,(PTR*)&tunnCb)) == ROK);)
    {
      erabId = tunnCb->bearerId;
-     cmMemcpy(tunInfo,tunnCb,sizeof(NbUeTunInfo)); 
+     cmMemcpy(tunInfo,tunnCb,sizeof(NbUeTunInfo));
      ret  = cmHashListDelete(&(ueCb->tunnInfo), (PTR)tunnCb);
      if (ret == RFAILED)
      {
        NB_LOG_ERROR(&nbCb,"Failed to delete TunnelCb");
-            
+
      }
      NB_FREE(tunnCb, sizeof(NbUeTunInfo))
      tunnCb = NULLP;
@@ -1334,11 +1342,11 @@ PUBLIC S16 NbEnbX2HOTriggerReqHdl
 
    if (ROK != cmHashListInsert(&(ueCb->tunnInfo),(PTR)tunInfo,
      (U8 *) &tunInfo->bearerId,sizeof(U32)))
-   {   
+   {
      NB_FREE(tunInfo, sizeof(NbUeTunInfo))
      NB_LOG_ERROR(&nbCb, "Failed to Insert tunnel info ");
      RETVALUE(RFAILED);
-   }   
+   }
    NB_LOG_DEBUG(&nbCb,"Inserted new tun info\n");
 
    mme_ue_s1ap_id = ueCb->s1ConCb->mme_ue_s1ap_id;
@@ -1369,7 +1377,7 @@ PUBLIC S16 NbEnbX2HOTriggerReqHdl
    datEvt.peerId.val  = nbCb.mmeInfo.mmeId;
    datEvt.u.suConnId  = suConId;
    datEvt.enbId = ueCb->enbId;
- 
+
    /*Send S1AP Path Switch Request to MME*/
    if (NbIfmS1apConReq(&datEvt) != ROK)
    {
@@ -1386,13 +1394,13 @@ PUBLIC S16 NbEnbX2HOTriggerReqHdl
 #endif
 
 #ifdef MULTI_ENB_SUPPORT
-/* 
- * @details This function is used Process the Received 
+/*
+ * @details This function is used Process the Received
  *          enb COnfig Transfer from TFW.
  *
  * Function: NbEnbConfigTransferHdl
  *
- * @param[in] NbEnbConfigTrnsf *enbConfigTrnsf 
+ * @param[in] NbEnbConfigTrnsf *enbConfigTrnsf
  * @return  S16
  *  -# Success : ROK
  *  -# Failure : RFAILED

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -8,7 +8,7 @@
 
 /**********************************************************************
 
-    Name:  LTE S1SIM - ENODEB Application Module 
+    Name:  LTE S1SIM - ENODEB Application Module
 
      Type:     C include file
 
@@ -16,9 +16,9 @@
 
     File:  nb.h
 
-    Sid:   
+    Sid:
 
-    Prg:   
+    Prg:
 
 **********************************************************************/
 
@@ -92,7 +92,7 @@ extern "C" {
 #if (defined(NB_DBG_CIRLOG) || defined(SS_SEGV_SIG_HDLR))
 #include "wr_dbg_log.h"
 #endif /* WR_DBG_LOGS */
-#ifdef RLOG_REDIRECT 
+#ifdef RLOG_REDIRECT
 #define NB_REDIRECT_RLOGS 1
 #endif /* NB_DBG_LOGS */
 typedef U32                  NbMmeId;
@@ -105,12 +105,12 @@ typedef U32                  NbMmeId;
 #define NB_SRC_PROC_ID                 1
 #define NB_DST_PROC_ID                 0
 #define NB_MAX_PLMNS_PER_MME 32
-#define NB_MAX_GRPS_PER_MME  256  
-#define NB_MAX_CODES_PER_MME 256 
+#define NB_MAX_GRPS_PER_MME  256
+#define NB_MAX_CODES_PER_MME 256
 
 #define NB_MAX_GUMMEI_PER_MME 256
 #define NB_PLMNID_IE_LEN     3          /* Octets */
-#define NB_LAC_IE_LEN        2    
+#define NB_LAC_IE_LEN        2
 #define NB_NUM_TQENTRY                 100
 #define NB_MAX_SAPS                    10
 #define NB_MEM_REGION                  0
@@ -185,8 +185,8 @@ typedef U32                  NbMmeId;
 #define NB_200   200
 
 /* Maximum PAGING tti reference time. This is used when difference is taken
- * between the current time and the time in which paging message has been 
- * received. Once we reach this value, will be starting from zero. 
+ * between the current time and the time in which paging message has been
+ * received. Once we reach this value, will be starting from zero.
  * */
 #define NB_PAGING_TTI_TIME        10240
 #define NB_DEFAULT_PAGING_PRI        255
@@ -249,11 +249,11 @@ typedef struct _nbDelayUeCtxtRelCmpCb
  CmTimer   timer;
 }NbDelayUeCtxtRelCmpCb;
 
-typedef enum nbTmr 
+typedef enum nbTmr
 {
    NB_TMR_SZT_SAP_BND = 1,
    NB_TMR_EGT_SAP_BND,
-   NB_TMR_INACTIVITY, 
+   NB_TMR_INACTIVITY,
    NB_TMR_S1_RELOC_TMR,
    NB_TMR_S1_OVRL_TMR,
    NB_TMR_MME_SETUP_RSP,
@@ -287,7 +287,7 @@ typedef struct _nbUeTunInfo
    CmTptAddr sgwAddr;
 }NbUeTunInfo;
 
-struct _nbUeCb 
+struct _nbUeCb
 {
    CmHashListEnt ueHashEnt;
    U32 ueId;
@@ -332,7 +332,7 @@ typedef struct NbLiSapCb
    CmTimer                   timer;
    U8                        bndRetryCnt;
    U8                        maxBndRetry;
-   TmrCfg                    bndTmr;    
+   TmrCfg                    bndTmr;
 } NbLiSapCb;
 typedef struct _nbPlmnId
 {
@@ -425,7 +425,8 @@ typedef struct _EnbCb
    U32 tac;
    NbPlmnId plmnId;
    U32 enbType;
-}EnbCb; 
+   U8 plmn_length;
+} EnbCb;
 typedef struct _mutilEnbCfgInfo
 {
    Bool pres;
@@ -470,16 +471,16 @@ typedef struct _nbCb
    Bool                      x2HoDone;
 #endif
 }NbCb;
-/** @brief This structure is temparerly store on stack which contains 
+/** @brief This structure is temparerly store on stack which contains
  * UE specific Paging Message information.
  */
 typedef struct _nbPagingMsgInfo
 {
-   U8      ueIdenType;    /*!< UE-identity in paging record is 
+   U8      ueIdenType;    /*!< UE-identity in paging record is
                                either IMSI type or S-TMSI type */
    union
    {
-      NbuSTmsi  sTMSI;      /*!< S-TMSI of the UE*/ 
+      NbuSTmsi  sTMSI;      /*!< S-TMSI of the UE*/
       U8       imsi[22];   /*!< IMSI of the UE. IMSI size is
                              min-6 Integer digits and
                              max-21 Integer Digits.As we are using
@@ -490,7 +491,7 @@ typedef struct _nbPagingMsgInfo
    Bool    pagingDrxPres;   /*!< set to TRUE, if UE specific DRX cycle present,
                                  otherwise set to FALSE */
    U8      ueSpcPagDrx; /* UE specific DRX Cycle */
-   U8      domIndType;   /*!< Domain indication is either PS or CS 
+   U8      domIndType;   /*!< Domain indication is either PS or CS
                               which is received thru S1-AP paging message*/
    U8      pagPriority;  /*!< Priority of paging Message */
 } NbPagingMsgInfo;
@@ -515,7 +516,7 @@ typedef struct _nbResetAck
 #define NB_GET_S1AP_CON_ID(_suConId,_ptr) {\
        _suConId = ((nbCb.cellId & 0xFFFF) << 16)\
                   |(_ptr->ueId & 0xFFFF);\
-} 
+}
 
 #define NB_FREE(_buf, _size)          \
 {\
@@ -534,10 +535,10 @@ typedef struct _nbResetAck
 #ifndef NB_DBG_CIRLOG
 #define NB_PRNT_BUF                    nbCb.init.prntBuf
 #else
-/* Currently passing index as zero, when multiple system tasks are used then 
+/* Currently passing index as zero, when multiple system tasks are used then
  * retrieve the corresponding circular buffer for that system task.
  */
-#define NB_PRNT_BUF                    nbCb.init.prntCirBuf, MAX_LOG_BUF_SIZE 
+#define NB_PRNT_BUF                    nbCb.init.prntCirBuf, MAX_LOG_BUF_SIZE
 #endif /* NB_DBG_CIRLOG */
 #define DBGMASK_SM                     1
 #define NB_EVEBASE                     0
@@ -551,7 +552,7 @@ typedef struct _nbResetAck
 #define NB_DFLT_K_VAL_FOR_SCH 1
 
 /* ccpu00133012:The UL Carrier Frequency is derived for DL Carrier Frequency. The
-   difference is sepc defined gievn in 36.101. But this specific requirement is to 
+   difference is sepc defined gievn in 36.101. But this specific requirement is to
    cater the KT requirement.
 */
 #define NB_SET_ZERO(_buf, _size) \
@@ -564,7 +565,7 @@ typedef struct _nbResetAck
       {                                                         \
                NB_SET_ZERO((*_buf), _size);                           \
       } \
-} 
+}
 #define NB_FREEMBUF(_mBuf)                            \
    do{                                                   \
       if (_mBuf != NULLP)                                \
@@ -597,7 +598,7 @@ typedef struct _nbResetAck
 *************************************************************************/
 #define NB_ERROR 1
 
-#ifdef NB_DBG_CIRLOG 
+#ifdef NB_DBG_CIRLOG
 #define NB_DBGP(_msgClass, _arg) \
 {\
    DBGP_CIRLOG(&(nbCb.init), NBLAYERNAME": ", _msgClass, _arg); \
@@ -637,7 +638,7 @@ typedef struct _nbResetAck
    }
 #endif /* (NB_SM_LOG_TO_FILE && DEBUGP) */
 #else
-#define NB_DBGP(_msgClass, _arg) 
+#define NB_DBGP(_msgClass, _arg)
 #endif
 #endif /* NB_DBG_CIRLOG */
 /* initialize the memCp & allocate memory for the event structure */
@@ -854,7 +855,7 @@ typedef enum
    NB_DIAG_NA
 } NbDiagSplArg;
 
-/** 
+/**
  * @details Macro definition for WR level 0 logs
 */
 #define NB_DIAG_LVL0(_tknId, _splArgEnum, _splArg, _string, _arg1, _arg2, _arg3, _arg4)                                                         \
@@ -865,7 +866,7 @@ typedef enum
    }                                                                                                                                            \
 }
 
-/** 
+/**
  * @details Macro definition for WR level 1 logs
 */
 #define NB_DIAG_LVL1(_tknId, _splArgEnum, _splArg, _string, _arg1, _arg2, _arg3, _arg4)                                                         \
@@ -876,7 +877,7 @@ typedef enum
    }                                                                                                                                            \
 }
 
-/** 
+/**
  * @details Macro definition for WR level 2 logs
 */
 #define NB_DIAG_LVL2(_tknId, _splArgEnum, _splArg, _string, _arg1, _arg2, _arg3, _arg4)                                                         \
@@ -887,8 +888,8 @@ typedef enum
    }                                                                                                                                            \
 }
 
-/** 
- * @details Macro definition for WR  level 3 logs 
+/**
+ * @details Macro definition for WR  level 3 logs
 */
 #define NB_DIAG_LVL3(_tknId, _splArgEnum, _splArg, _string, _arg1, _arg2, _arg3, _arg4)                                                         \
 {                                                                                                                                               \
@@ -898,7 +899,7 @@ typedef enum
    }                                                                                                                                            \
 }
 
-/** 
+/**
  * @details Macro definition for WR  level 4 logs
 */
 #define NB_DIAG_LVL4(_tknId, _splArgEnum, _splArg, _string, _arg1, _arg2, _arg3, _arg4)                                                         \
@@ -909,7 +910,7 @@ typedef enum
    }                                                                                                                                            \
 }
 
-/** 
+/**
  * @details Macro definition for TeNB APP Varible length logs
 */
 #define NB_DIAG_VAR(_tknId, _splArgEnum, _splArg, _string, _stringPtr)                                                         \

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -144,7 +144,7 @@ PUBLIC S16 NbHandleInitialUeMsg
 
    establishCause = initialUeMsg->rrcCause;
 
-   stmsi.pres  = initialUeMsg->stmsi.pres; 
+   stmsi.pres  = initialUeMsg->stmsi.pres;
    stmsi.mmec  = initialUeMsg->stmsi.mmec;
    stmsi.mTMSI = initialUeMsg->stmsi.mTMSI;
 
@@ -171,7 +171,7 @@ PUBLIC S16 NbHandleInitialUeMsg
 #ifdef MULTI_ENB_SUPPORT
    datEvt.enbId = ueCb->enbId;
 #endif
- 
+
    if (ROK != cmHashListInsert(&(nbCb.ueCbLst),(PTR)ueCb,
                      (U8 *) &ueCb->ueId,sizeof(U8)))
    {
@@ -233,7 +233,7 @@ PRIVATE S16 nbS1apBldInitUePdu
 
    NB_LOG_DEBUG(&nbCb, "Building Initial UE Message");
 
-   if (cmAllocEvnt(sizeof(S1apPdu), SZ_MEM_SDU_SIZE, &nbCb.mem, 
+   if (cmAllocEvnt(sizeof(S1apPdu), SZ_MEM_SDU_SIZE, &nbCb.mem,
             (Ptr *)&initUePdu) != ROK)
    {
       NB_LOG_ERROR(&nbCb, "Failed to allocate memory. cmAllocEvnt Failed");
@@ -260,15 +260,15 @@ PRIVATE S16 nbS1apBldInitUePdu
    }
    /* IE1 - Filling enb s1ap id */
    ie = &initUeMsg->protocolIEs.member[ieIdx++];
-   nbFillTknU8(&(ie->pres), PRSNT_NODEF);     
+   nbFillTknU8(&(ie->pres), PRSNT_NODEF);
    nbFillTknU32(&(ie->id), Sztid_eNB_UE_S1AP_ID);
    nbFillTknU32(&(ie->criticality), SztCriticalityrejectEnum);
-   nbFillTknU32(&(ie->value.u.sztENB_UE_S1AP_ID), 
+   nbFillTknU32(&(ie->value.u.sztENB_UE_S1AP_ID),
          ueCb->s1ConCb->enb_ue_s1ap_id);
 
    /* IE2 - Filling nas pdu */
    ie = &initUeMsg->protocolIEs.member[ieIdx++];
-   nbFillTknU8(&(ie->pres), PRSNT_NODEF);     
+   nbFillTknU8(&(ie->pres), PRSNT_NODEF);
    nbFillTknU32(&(ie->id), Sztid_NAS_PDU);
    nbFillTknU32(&(ie->criticality), SztCriticalityrejectEnum);
    nbFillTknStrOSXL(&(ie->value.u.sztNAS_PDU), nasPdu->len, nasPdu->val,
@@ -276,10 +276,10 @@ PRIVATE S16 nbS1apBldInitUePdu
 
    /* IE3 - Filling TAI */
    ie = &initUeMsg->protocolIEs.member[ieIdx++];
-   nbFillTknU8(&(ie->pres), PRSNT_NODEF);     
+   nbFillTknU8(&(ie->pres), PRSNT_NODEF);
    nbFillTknU32(&(ie->id), Sztid_TAI);
    nbFillTknU32(&(ie->criticality), SztCriticalityrejectEnum);
-   nbFillTknU8(&(ie->value.u.sztTAI.pres), PRSNT_NODEF);     
+   nbFillTknU8(&(ie->value.u.sztTAI.pres), PRSNT_NODEF);
    nbSztFillPLMNId(initUePdu, &tai->plmnId, &(ie->value.u.sztTAI.pLMNidentity));
    nbSztFillTAC(tai->tac, initUePdu, &(ie->value.u.sztTAI.tAC));
 
@@ -301,7 +301,7 @@ PRIVATE S16 nbS1apBldInitUePdu
    nbFillTknU8(&(ie->pres), PRSNT_NODEF);
    nbFillTknU32(&(ie->id), Sztid_RRC_Establishment_Cause);
    nbFillTknU32(&(ie->criticality), SztCriticalityignoreEnum );
-   nbFillTknU32(&(ie->value.u.sztRRC_Establishment_Cause), 
+   nbFillTknU32(&(ie->value.u.sztRRC_Establishment_Cause),
          establishCause);
 
    /*IE6 - Filling STMSI */
@@ -314,7 +314,7 @@ PRIVATE S16 nbS1apBldInitUePdu
 
       nbFillTknU8(&(ie->value.u.sztS_TMSI.pres), PRSNT_NODEF);
       nbFill2TknStr4(&(ie->value.u.sztS_TMSI.mMEC), 1, (U8 *)&sTMSI.mmec);
-      nbFillTknStrOSXL1(&(ie->value.u.sztS_TMSI.m_TMSI), 4, sTMSI.mTMSI, 
+      nbFillTknStrOSXL1(&(ie->value.u.sztS_TMSI.m_TMSI), 4, sTMSI.mTMSI,
                                                              &initUePdu->memCp);
       ie->value.u.sztS_TMSI.iE_Extns.noComp.pres = NOTPRSNT;
    }
@@ -325,7 +325,7 @@ PRIVATE S16 nbS1apBldInitUePdu
    RETVALUE(ROK);
 }
 
-PUBLIC S16 nbSendErabsRelInfo 
+PUBLIC S16 nbSendErabsRelInfo
 (
  NbErabRelLst *erabInfo
 )
@@ -337,7 +337,7 @@ PUBLIC S16 nbSendErabsRelInfo
    msg->ueId = erabInfo->enbUeS1apId;
    /* pack and send to ue */
    NB_ALLOC(&msg->erabInfo, sizeof(NbuErabRelLst));
-   msg->erabInfo->numOfErab = erabInfo->numOfErabIds; 
+   msg->erabInfo->numOfErab = erabInfo->numOfErabIds;
    NB_ALLOC(&msg->erabInfo->rabCbs, (erabInfo->numOfErabIds * sizeof(NbuErabRelCb)));
 
    for(idx = 0; idx < erabInfo->numOfErabIds; idx++)
@@ -371,7 +371,7 @@ PUBLIC S16 nbSendErabsRelInfo
    RETVALUE(ROK);
 }
 
-PUBLIC S16 nbSendErabsInfo 
+PUBLIC S16 nbSendErabsInfo
 (
  NbUeCb *ueCb,
  NbErabLst *erabInfo,
@@ -388,7 +388,7 @@ PUBLIC S16 nbSendErabsInfo
    msg->ueRadCapRcvd = ueRadCapRcvd;
    /* pack and send to ue */
    NB_ALLOC(&msg->erabInfo, sizeof(NbuErabLst));
-   msg->erabInfo->numOfErab = erabInfo->noOfComp; 
+   msg->erabInfo->numOfErab = erabInfo->noOfComp;
    NB_ALLOC(&msg->erabInfo->rabCbs, (erabInfo->noOfComp * sizeof(NbuErabCb)));
 
    for(idx = 0; idx < erabInfo->noOfComp; idx++)
@@ -492,7 +492,7 @@ PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
    }
    /* set the datrcvd flag for ue */
    nbDamSetDatFlag(ueId);
-   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr,bearerId)); 
+   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr,bearerId));
 }
 
 PUBLIC Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId)
@@ -529,8 +529,8 @@ PUBLIC S16 nbNotifyPlmnInfo(U8 ueId, NbPlmnId plmnId )
   }
   else
   {
-     msg->plmnId[1] =(((plmnId.mnc[0])<<4) | (plmnId.mcc[2]));
-     msg->plmnId[2] =(((plmnId.mnc[2])<<4) | (plmnId.mnc[1]));
+    msg->plmnId[1] = (((plmnId.mnc[2]) << 4) | (plmnId.mcc[2]));
+    msg->plmnId[2] = (((plmnId.mnc[1]) << 4) | (plmnId.mnc[0]));
   }
   /* Send the PLMN Info to UEAPP */
   ret = cmPkNbuNotifyPlmnInfo(&nbCb.ueAppPst, msg);

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -9,7 +9,7 @@
 
 /********************************************************************20**
 
-     Name:     
+     Name:
 
      Type:     C source file
 
@@ -17,8 +17,8 @@
 
      File:     nbt.x
 
-     Sid:      
-     Prg:      
+     Sid:
+     Prg:
 
 
 *******************************************************************21 */
@@ -159,14 +159,14 @@ typedef struct  _nbS1SetupRsp
 
 typedef struct _nbConfigReq
 {
-   U16   cellId;                  /* cell id */            
+   U16   cellId;                  /* cell id */
    U16   tac;                     /* tracking area code*/
-   U32   enbIpAddr;               /* enodeb address */ 
+   U32   enbIpAddr;               /* enodeb address */
    U16   mmeId;                   /* mme id */
    U32   mmeAddr;                 /* mme code */
-   U32   sctpIpAddr;              /* sctp address */ 
+   U32   sctpIpAddr;              /* sctp address */
    U8    enbName[151];            /* enodeb name */
-   U8    plmnId[NBT_MAX_PLMN_ID]; /*  plmn  */ 
+   U8    plmnId[NBT_MAX_PLMN_ID]; /*  plmn  */
    U32   heartBeatInterval;       /* sctp heartbeat timer value */
    U32   rtoInitial;              /* sctp rto initial */
    U32   rtoMin;                  /* sctp rto min */
@@ -189,7 +189,7 @@ typedef struct _nbConfigReq
 typedef struct _nbConfigCfm
 {
  CfgSts       status;
- CfgFailCause cause; 
+ CfgFailCause cause;
 }NbConfigCfm;
 
 typedef struct _nbRelCause
@@ -323,7 +323,7 @@ typedef struct _nbIntCtxtSetUpInd
    U8 ueId;
    U8 status;
 }NbIntCtxtSetUpInd;
-typedef struct _nbIntCtxtSetUpDrpdInd 
+typedef struct _nbIntCtxtSetUpDrpdInd
 {
    U8 ueId;
 }NbIntCtxtSetUpDrpdInd;
@@ -379,14 +379,16 @@ typedef struct _nbmultiEnbCfgParam
    U32 tac;
    U8 plmn_id[NBT_MAX_PLMN_ID];
    U32 enbType;
+   U8 plmn_length;
 }NbmultiEnbCfgParam;
+
 typedef struct _nbMultiEnbConfigReq
 {
    U32 numOfEnbs;
    NbmultiEnbCfgParam nbMultiEnbCfgParam[NBT_MAX_NUM_OF_ENBS];
 }NbMultiEnbConfigReq;
 
-typedef struct _nbX2HOTriggerReq 
+typedef struct _nbX2HOTriggerReq
 {
    U8 ueId;
 }NbX2HOTriggerReq;
@@ -427,7 +429,7 @@ typedef struct _nbtMsg
    {
       NbConfigReq     configReq;
       NbConfigCfm     configCfm;
-      NbS1SetupRsp    s1SetupRsp; 
+      NbS1SetupRsp    s1SetupRsp;
       NbUeCntxtRelReq ueCntxtRelReq;
       NbResetRequest  resetReq;
       NbResetAckldg   resetAck;
@@ -439,13 +441,13 @@ typedef struct _nbtMsg
       NbIntCtxtSetUpDrpdInd intCtxtSetUpDrpdInd;
       NbErrIndMsg     s1ErrIndMsg;
       NbSctpAbortReqMsg  sctpAbortReqMsg;
-      NbInitCtxtSetupFail initCtxtSetupFail; 
-      NbDropInitCtxtSetup dropInitCtxtSetup; 
+      NbInitCtxtSetupFail initCtxtSetupFail;
+      NbDropInitCtxtSetup dropInitCtxtSetup;
       NbDelayICSRsp      delayInitCtxtSetupRsp;
-      NbSendUeCtxtRelForICSRsp sendUeCtxtRelForICS; 
+      NbSendUeCtxtRelForICSRsp sendUeCtxtRelForICS;
       NbNasNonDel    nasNondel;
       NbNasNonDelRsp  nasNondelRsp;
-      NbDelayUeCtxtRelCmp delayUeCtxtRelCmp; 
+      NbDelayUeCtxtRelCmp delayUeCtxtRelCmp;
       NbMultiEnbConfigReq multiEnbConfigReq;
       NbX2HOTriggerReq    x2HOTriggerReq;
       NbPathSwReqAck      pathSwReqAck;
@@ -456,7 +458,7 @@ typedef struct _nbtMsg
 }NbtMsg;
 
 /* nbt Interface general Structure declerations */
-typedef NbtMsg   NbtRequest;      
+typedef NbtMsg   NbtRequest;
 
 typedef NbtMsg   NbtResponse;
 
@@ -482,6 +484,6 @@ EXTERN S16 nbUiSendIntCtxtSetupIndToUser(U8 ueId, U8 status);
 EXTERN S16 nbUiSendErabRelCmdInfoToUser(NbErabRelCmd *erabRelInfo);
 /********************************************************************30**
 
-         End of file:     
+         End of file:
 
 *********************************************************************31*/

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -9,17 +9,17 @@
 /********************************************************************20**
 
     Name:  LTE S1SIM - TFW API
- 
+
     Type:  C include file
- 
+
     Desc:  C source code for Test Framework interface API with Stub.
- 
+
     File:  fw_api_int.c
- 
-    Sid:   
- 
-    Prg:   
- 
+
+    Sid:
+
+    Prg:
+
 **********************************************************************/
 
 #include "envopt.h"        /* environment options */
@@ -105,7 +105,7 @@ PRIVATE Void handlPdnDisconnectReq(uepdnDisconnectReq_t *data);
 EXTERN Void fwHndlPdnDisconnTmrExp(PTR cb);
 PUBLIC FwCb gfwCb;
 
-/* Adding UEID, epsupdate type, active flag into linked list for 
+/* Adding UEID, epsupdate type, active flag into linked list for
  * TAU request
  */
 PRIVATE Void insertUeCb(U8 ueid, U8 epsUpdType, U8 flag, UeIdCb *ueIdCb)
@@ -113,7 +113,7 @@ PRIVATE Void insertUeCb(U8 ueid, U8 epsUpdType, U8 flag, UeIdCb *ueIdCb)
    FwCb *fwCb = NULLP;
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
+
    ueIdCb->ue_id = ueid;
    ueIdCb->epsUpdType = epsUpdType;
    ueIdCb->ActvFlag = flag;
@@ -124,18 +124,18 @@ PRIVATE Void insertUeCb(U8 ueid, U8 epsUpdType, U8 flag, UeIdCb *ueIdCb)
 }
 
 /*
- * 
+ *
  *   Fun:   handlTauReq
- * 
- *   Desc:  This function is used to handle Tracking area update request 
+ *
+ *   Desc:  This function is used to handle Tracking area update request
  *          from Test Controller.
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlTauReq(ueTauReq_t* data)
 {
@@ -159,7 +159,7 @@ PUBLIC S16 handlTauReq(ueTauReq_t* data)
    ueTauReq->epsUpdtType = data->type;
    ueTauReq->ActvFlag = data->Actv_flag;
    fwSendToUeApp(uetMsg);
-   
+
    FW_LOG_DEBUG(fwCb, "\n-------------------------------\n\
             Starting T3430\n-------------------------------\n");
    ret = fwStartTmr(fwCb, ueIdCb, fwHndlTauTmrExp, 2000000);
@@ -168,20 +168,20 @@ PUBLIC S16 handlTauReq(ueTauReq_t* data)
       FW_LOG_ERROR(fwCb, "Failed to start T3430 timer");
    }
    FW_LOG_EXITFN(fwCb, ROK);
-} 
+}
 
 /*
  *   Fun:   handlTauComp
- * 
- *   Desc:  This function is used to handle Tracking area update complete 
+ *
+ *   Desc:  This function is used to handle Tracking area update complete
  *          from Test Controller.
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlTauComp(ueTauComplete_t* data)
 {
@@ -202,18 +202,18 @@ PUBLIC S16 handlTauComp(ueTauComplete_t* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlServiceReq
- * 
- *   Desc:  This function is used to handle Service request 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Service request
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handlServiceReq(ueserviceReq_t* data)
 {
@@ -224,15 +224,15 @@ PUBLIC Void handlServiceReq(ueserviceReq_t* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(uetMsg), 0, sizeof(UetMessage));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK)
+   {
+      cmMemset((U8 *)(uetMsg), 0, sizeof(UetMessage));
    }
    else
    {
       RETVOID;
-   }   
+   }
    uetMsg->msgType = UE_SERVICE_REQUEST_TYPE;
    ueServiceReq = &uetMsg->msg.ueUetServiceReq;
 
@@ -246,18 +246,18 @@ PUBLIC Void handlServiceReq(ueserviceReq_t* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlUeCntxtRelReq
- * 
- *   Desc:  This function is used to handle Service request 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Service request
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handlUeCntxtRelReq(ueCntxtRelReq_t* data)
 {
@@ -266,11 +266,11 @@ PUBLIC Void handlUeCntxtRelReq(ueCntxtRelReq_t* data)
 
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -288,18 +288,18 @@ PUBLIC Void handlUeCntxtRelReq(ueCntxtRelReq_t* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlDetachReq
- * 
- *   Desc:  This function is used to handle Detach request 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Detach request
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlDetachReq(uedetachReq_t* data)
 {
@@ -321,18 +321,18 @@ PUBLIC S16 handlDetachReq(uedetachReq_t* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlAttachComp
- * 
- *   Desc:  This function is used to handle Attach complete message 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Attach complete message
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlAttachComp(ueAttachComplete_t *data)
 {
@@ -352,18 +352,18 @@ PUBLIC S16 handlAttachComp(ueAttachComplete_t *data)
    FW_LOG_EXITFN(fwCb, ROK);
 }
 /*
- * 
+ *
  *   Fun:   handleActvDfltEpsBearerContextRej
- * 
- *   Desc:  This function is used to handle Attach complete + Activate Default Eps Bearer context reject message 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Attach complete + Activate Default Eps Bearer context reject message
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handleActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data)
 {
@@ -385,18 +385,18 @@ PUBLIC S16 handleActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data)
    FW_LOG_EXITFN(fwCb, ROK);
 }
 /*
- * 
+ *
  *   Fun:   handlIdentResp
- * 
+ *
  *   Desc:  This function is used to handle Identity Response coming from
  *          Test Controller.
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlIdentResp(ueIdentityResp_t *data)
 {
@@ -418,18 +418,18 @@ PUBLIC S16 handlIdentResp(ueIdentityResp_t *data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlSecModComp
- * 
- *   Desc:  This function is used to handle Security mode complete 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Security mode complete
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlSecModComp(ueSecModeComplete_t *data)
 {
@@ -450,18 +450,18 @@ PUBLIC S16 handlSecModComp(ueSecModeComplete_t *data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlSecModRej
- * 
- *   Desc:  This function is used to handle Security mode Reject 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle Security mode Reject
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlSecModRej(ueSecModeReject_t *data)
 {
@@ -483,18 +483,18 @@ PUBLIC S16 handlSecModRej(ueSecModeReject_t *data)
 }
 
 /*
- * 
+ *
  *   Fun:   handlAuthResp
- * 
+ *
  *   Desc:  This function is used to handle Auth Response
- *          from Test Controller 
- * 
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlAuthResp(ueAuthResp_t *data)
 {
@@ -536,25 +536,25 @@ PUBLIC S16 handlAuthResp(ueAuthResp_t *data)
    {
       uetMsg->msg.ueUetAuthRsp.randRcvd.pres = FALSE;
    }
-   
+
 
    fwSendToUeApp(uetMsg);
    RETVALUE(ROK);
 }
 
 /*
- * 
+ *
  *   Fun:   handlRadCapUpd
- * 
+ *
  *   Desc:  This function is used to handle UE Radio Capability Update
- *          from Test Controller 
- * 
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC S16 handlRadCapUpd(ueRadCapUpd_t *data)
 {
@@ -585,7 +585,7 @@ PRIVATE Void insert_ue_entry(U8 ueid, UeIdCb *ueIdCb)
    FwCb *fwCb = NULLP;
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
+
    ueIdCb->ue_id = ueid;
    ueIdCb->state = UE_ATTACH_REQUEST_DONE;
    ueIdCb->link.node = (PTR)ueIdCb;
@@ -598,8 +598,8 @@ PRIVATE Void insert_ue_entry(U8 ueid, UeIdCb *ueIdCb)
  *
  *   Fun:   handleEndToEndAttachReq
  *
- *   Desc:  This function is used to handle Attach request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Attach request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -699,16 +699,16 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
 	  {
 	  	ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
 	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
-			   data->protCfgOpts_pr.p[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
+			   data->protCfgOpts_pr.p[count].val,
 			   data->protCfgOpts_pr.p[count].len);
 	  }
 	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
 	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
-			   data->protCfgOpts_pr.c[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
+			   data->protCfgOpts_pr.c[count].val,
 			   data->protCfgOpts_pr.c[count].len);
 	  }
    }
@@ -741,8 +741,8 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
  *
  *   Fun:   handleAttachReq
  *
- *   Desc:  This function is used to handle Attach request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Attach request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -836,18 +836,18 @@ PUBLIC S16 handleAttachReq(ueAttachRequest_t *data)
 	  for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
-			   data->protCfgOpts_pr.p[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
+			   data->protCfgOpts_pr.p[count].val,
 			   data->protCfgOpts_pr.p[count].len);
 	  }
 	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
-			   data->protCfgOpts_pr.c[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
+			   data->protCfgOpts_pr.c[count].val,
 			   data->protCfgOpts_pr.c[count].len);
 	  }
-   }  
+   }
    if(data->drxParm_pr.pres)
    	{
    	  ueAttachReq->drxParm.pres = TRUE;
@@ -863,14 +863,14 @@ PUBLIC S16 handleAttachReq(ueAttachRequest_t *data)
    }
    fwSendToUeApp(uetMsg);
    FW_LOG_EXITFN(fwCb, ROK);
-}   
+}
 
 /*
  *
  *   Fun:   handleUeAppConfig
  *
- *   Desc:  This function is used to handle Ue App Config request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Ue App Config request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -918,8 +918,8 @@ PUBLIC S16 handleUeAppConfig(ueAppConfig_t *data)
  *
  *   Fun:   handleUeConfig
  *
- *   Desc:  This function is used to handle Ue config request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Ue config request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -937,7 +937,7 @@ PUBLIC S16 handleUeConfig(ueConfig_t *data)
 
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
+
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    cmMemset((U8 *)uetMsg, 0, sizeof(UetMessage));
 
@@ -1008,14 +1008,14 @@ PUBLIC S16 handleUeConfig(ueConfig_t *data)
    }
    else
    {
-      ueCfg->ueNwCap.eea0 = fwCb->ueCfgCb.ueNwCap.eea0; 
+      ueCfg->ueNwCap.eea0 = fwCb->ueCfgCb.ueNwCap.eea0;
       ueCfg->ueNwCap.eea1_128 = fwCb->ueCfgCb.ueNwCap.eea1_128;
       ueCfg->ueNwCap.eea2_128 = fwCb->ueCfgCb.ueNwCap.eea2_128;
       ueCfg->ueNwCap.eia0 = fwCb->ueCfgCb.ueNwCap.eia0;
       ueCfg->ueNwCap.eia1_128 = fwCb->ueCfgCb.ueNwCap.eia1_128;
       ueCfg->ueNwCap.eia2_128 = fwCb->ueCfgCb.ueNwCap.eia2_128;
    }
-      
+
 
    if (data->opKey_pr.pres == TRUE)
       cmMemcpy((U8*)ueCfg->opKey, (U8*)data->opKey_pr.op_key,
@@ -1054,8 +1054,8 @@ PUBLIC S16 handleUeConfig(ueConfig_t *data)
  *
  *   Fun:   handleUeRadCapConfig
  *
- *   Desc:  This function is used to handle Ue config request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Ue config request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -1073,13 +1073,13 @@ PUBLIC S16 handleUeRadCapConfig(ueRadCapUpd_t *data)
 
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
+
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    cmMemset((U8 *)uetMsg, 0, sizeof(UetMessage));
    /* copying mandatory feilds */
    uetMsg->msgType = UE_RAD_CAP_UPD_TYPE;
    ueCfg = &uetMsg->msg.ueUetRadCapUpdReq;
-  
+
    ueCfg->ueId = data->ue_Id;
    ueCfg->send_s1ap_msg = data->snd_S1AP;
    if(data->radioCap_pr.len > 0)
@@ -1105,9 +1105,9 @@ PUBLIC S16 handleUeRadCapConfig(ueRadCapUpd_t *data)
 } /* handleUeRadCapConfig */
 
 /*
- *       Fun:  handlUeTrigDetachAccept 
+ *       Fun:  handlUeTrigDetachAccept
  *
- *       Desc:  This function is used to handle Detach Accept 
+ *       Desc:  This function is used to handle Detach Accept
  *              from Test Controller and sends to ueApp
  *
  *       Ret:   None
@@ -1127,20 +1127,20 @@ PRIVATE S16 handlUeTrigDetachAccept(ueTrigDetachAcceptInd_t *data)
 
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    cmMemset((U8 *)uetMsg, 0, sizeof(UetMessage));
-   
+
    uetMsg->msgType = UE_TRIG_DETACH_ACCEPT_TYPE;
    uetMsg->msg.ueUetUeTrigDetachAcc.ueId = data->ue_Id;
-    
+
    fwSendToUeApp(uetMsg);
 
    FW_LOG_EXITFN(fwCb, ROK);
 }
 
 /*
- * 
- *       Fun:  handlUeFlushCmnd 
  *
- *       Desc:  This function is used to handle Flush Command 
+ *       Fun:  handlUeFlushCmnd
+ *
+ *       Desc:  This function is used to handle Flush Command
  *              from Test Controller and sends to ueApp
  *
  *       Ret:   None
@@ -1160,10 +1160,10 @@ PRIVATE S16 handlUeFlushCmnd(ueFlush_t *data)
 
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    cmMemset((U8 *)uetMsg, 0, sizeof(UetMessage));
-   
+
    uetMsg->msgType = UE_FLUSH_TYPE;
    uetMsg->msg.ueUetFlush.noOfUe = data->noOfUe;
-    
+
    fwSendToUeApp(uetMsg);
 
    FW_LOG_EXITFN(fwCb, ROK);
@@ -1173,8 +1173,8 @@ PRIVATE S16 handlUeFlushCmnd(ueFlush_t *data)
  *
  *       Fun:   handlEnbConfig
  *
- *       Desc:  This function is used to handle EnodeB config request 
- *              from Test Controller 
+ *       Desc:  This function is used to handle EnodeB config request
+ *              from Test Controller
  *
  *       Ret:   None
  *
@@ -1483,18 +1483,18 @@ PUBLIC S16 handlEnbInactvTmrCfg(FwNbConfigReq_t *data)
 }
 
 /*
- * 
- *     Fun:  handlS1SetupReq 
- * 
- *     Desc:  This function is used to handle S1-SETUP Request 
+ *
+ *     Fun:  handlS1SetupReq
+ *
+ *     Desc:  This function is used to handle S1-SETUP Request
  *            from Test Controller.
- * 
+ *
  *     Ret:   None
- * 
+ *
  *     Notes: None
- * 
+ *
  *     File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE S16 handlS1SetupReq(Void)
 {
@@ -1594,7 +1594,7 @@ PUBLIC S16 handleFwErabRelInd(FwErabRelInd_t *data)
 
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    cmMemset((U8 *)uetMsg, 0, sizeof(UetMessage));
-   
+
    uetMsg->msgType = UE_ERAB_REL_IND;
    uetMsg->msg.ueErabRelInd.ueId = data->ueId;
    uetMsg->msg.ueErabRelInd.numOfErabIds = data->numOfErabIds;
@@ -1604,7 +1604,7 @@ PUBLIC S16 handleFwErabRelInd(FwErabRelInd_t *data)
          data->numOfErabIds);
    fwSendToUeApp(uetMsg);
 
-   FW_LOG_EXITFN(fwCb, ROK); 
+   FW_LOG_EXITFN(fwCb, ROK);
 } /* handleFwErabRelInd_t */
 
 PUBLIC S16 handleFwErabRelRsp(FwErabRelRsp_t *data)
@@ -1638,8 +1638,8 @@ PUBLIC S16 handleFwErabRelRsp(FwErabRelRsp_t *data)
  *
  *   Fun:   handleEmmStatus
  *
- *   Desc:  This function is used to handle EMM STATUS 
- *          from Test Controller 
+ *   Desc:  This function is used to handle EMM STATUS
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -1671,18 +1671,18 @@ PUBLIC S16 handleEmmStatus(ueEmmStatus_t *data)
 }
 
 /*
- * 
+ *
  *   Fun:   handleX2HoTriggerReq
- * 
- *   Desc:  This function is used to handle X2 HO request 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle X2 HO request
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handleX2HoTriggerReq(NbX2HOTriggerReq* data)
 {
@@ -1691,11 +1691,11 @@ PUBLIC Void handleX2HoTriggerReq(NbX2HOTriggerReq* data)
 
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -1711,18 +1711,18 @@ PUBLIC Void handleX2HoTriggerReq(NbX2HOTriggerReq* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handleEnbConfigTrnsf
- * 
+ *
  *   Desc:  This function is used to handle enb Config Transfer
- *          from Test Controller 
- * 
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handleEnbConfigTransfer(NbEnbConfigTrnsf* data)
 {
@@ -1731,11 +1731,11 @@ PUBLIC Void handleEnbConfigTransfer(NbEnbConfigTrnsf* data)
 
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
-   
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -1753,8 +1753,8 @@ PUBLIC Void handleEnbConfigTransfer(NbEnbConfigTrnsf* data)
 /*
  *   Fun:   tfwApi
  *
- *   Desc:  This function is used to distinguish the messages from  
- *          Test controller based on message type and call the 
+ *   Desc:  This function is used to distinguish the messages from
+ *          Test controller based on message type and call the
  *          corresponding handler function.
  *
  *   Ret:   ROK
@@ -1772,7 +1772,7 @@ PUBLIC S16 tfwApi
 {
    S16 ret = ROK;
    FwCb  *fwCb = NULLP;
-  
+
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
@@ -1798,7 +1798,7 @@ PUBLIC S16 tfwApi
          break;
       }
       case UE_RAD_CAP_UPDATE_REQ:
-      {   
+      {
          FW_LOG_DEBUG(fwCb, "ueRadCapabilityConfig");
          handleUeRadCapConfig((ueRadCapUpd_t*)msg);
          break;
@@ -1820,7 +1820,7 @@ PUBLIC S16 tfwApi
          FW_LOG_DEBUG(fwCb, "S1 SETUP-REQ");
          switch(fwCb->nbState)
          {
-            case NB_CONFIG_DONE: 
+            case NB_CONFIG_DONE:
             {
                handlS1SetupReq();
                break;
@@ -1882,7 +1882,7 @@ PUBLIC S16 tfwApi
          if (fwCb->nbState == ENB_IS_UP)
          {
             handlAuthResp((ueAuthResp_t*)msg);
-         }  
+         }
          else
          {
             FW_LOG_ERROR(fwCb, "FAILED TO SEND UE_AUTH_RESP: "\
@@ -2160,7 +2160,7 @@ PUBLIC S16 tfwApi
             ret = RFAILED;
          }
          break;
-      } 
+      }
       case UE_SET_INIT_CTXT_SETUP_FAIL:
       {
          FW_LOG_DEBUG(fwCb, "Initial context setup Fail");
@@ -2385,18 +2385,18 @@ Void initTestFrameWork(TestCnrlrCallBack func)
 } /* initTestFrameWork */
 
 /*
- * 
+ *
  *   Fun:   handlPdnConnReq
- * 
- *   Desc:  This function is used to handle PDN connectivity Request 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle PDN connectivity Request
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
 {
@@ -2409,25 +2409,25 @@ PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-            (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(uetMsg), 0,sizeof(UetMessage));              
-   }
-   else
+   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
+            (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK)
    {
-      RETVOID;
-   }   
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-            (Data **)&ueIdCb, (Size) sizeof(UeIdCb)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(ueIdCb), 0,sizeof(UeIdCb));              
+      cmMemset((U8 *)(uetMsg), 0,sizeof(UetMessage));
    }
    else
    {
       RETVOID;
    }
-   
+   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
+            (Data **)&ueIdCb, (Size) sizeof(UeIdCb)) == ROK)
+   {
+      cmMemset((U8 *)(ueIdCb), 0,sizeof(UeIdCb));
+   }
+   else
+   {
+      RETVOID;
+   }
+
    insertUeCb(data->ue_Id, 0, 0, ueIdCb);
    uetMsg->msgType = UE_PDN_CON_REQ_TYPE;
    uePdnConReq = &uetMsg->msg.ueUetPdnConReq;
@@ -2453,10 +2453,10 @@ PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
 
 /*
  *
- *       Fun:   handlErrIndMsg 
+ *       Fun:   handlErrIndMsg
  *
- *       Desc:  This function is used to handle Error Indication Msg 
- *              from Test Controller 
+ *       Desc:  This function is used to handle Error Indication Msg
+ *              from Test Controller
  *
  *       Ret:   None
  *
@@ -2479,8 +2479,8 @@ PRIVATE S16 handlErrIndMsg(fwNbErrIndMsg_t *data)
    msgReq->msgType = NB_ERR_IND_MSG;
    msgReq->t.s1ErrIndMsg.isUeAssoc = data->isUeAssoc;
    if(data->isUeAssoc == TRUE)
-   { 
-      msgReq->t.s1ErrIndMsg.ue_Id = data->ue_Id; 
+   {
+      msgReq->t.s1ErrIndMsg.ue_Id = data->ue_Id;
    }
    if(data->cause.pres == TRUE)
    {
@@ -2511,16 +2511,16 @@ PRIVATE S16 handlErrIndMsg(fwNbErrIndMsg_t *data)
             data->criticalityDiag.procedureCriticality;
       }
       msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.noComp =
-         data->criticalityDiag.ieLst.noComp; 
+         data->criticalityDiag.ieLst.noComp;
       FW_ALLOC_MEM(fwCb, &msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.member, \
       sizeof(FwCriticalityDiag_IE_Item));
       for(idx = 0 ; idx < data->criticalityDiag.ieLst.noComp ; idx++)
-      { 
+      {
          if(data->criticalityDiag.ieLst.member[idx].pres  == TRUE)
          {
             msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.member[idx].pres = TRUE;
             msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.member[idx].iECriticality = \
-              data->criticalityDiag.ieLst.member[idx].iECriticality; 
+              data->criticalityDiag.ieLst.member[idx].iECriticality;
             msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.member[idx].iE_ID = \
               data->criticalityDiag.ieLst.member[idx].iE_ID;
             msgReq->t.s1ErrIndMsg.criticalityDiag.ieLst.member[idx].TypOfErr = \
@@ -2535,10 +2535,10 @@ PRIVATE S16 handlErrIndMsg(fwNbErrIndMsg_t *data)
 
 /*
  *
- *   Fun:   handleUeResAllocReq 
+ *   Fun:   handleUeResAllocReq
  *
- *   Desc:  This function is used to handle Attach request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Attach request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -2567,13 +2567,13 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
    bearAllocReq->bearerId       = data->bearerId;
    bearAllocReq->lnkEpsBearerId = data->lnkEpsBearerId;
 
-   bearAllocReq->epsQos.pres = data->qos.pres; 
+   bearAllocReq->epsQos.pres = data->qos.pres;
    if(bearAllocReq->epsQos.pres == TRUE)
    {
      bearAllocReq->epsQos.qci             = data->qos.qci;
      bearAllocReq->epsQos.lenQosCont      = data->qos.lenQosCont;
      bearAllocReq->epsQos.maxBitRateUL    = data->qos.maxBitRateUL;
-     bearAllocReq->epsQos.maxBitRateDL    = data->qos.maxBitRateDL; 
+     bearAllocReq->epsQos.maxBitRateDL    = data->qos.maxBitRateDL;
      bearAllocReq->epsQos.guaraBitRateUL  = data->qos.guaraBitRateUL;
      bearAllocReq->epsQos.guaraBitRateDL  = data->qos.guaraBitRateDL;
    }
@@ -2582,29 +2582,29 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
    if(bearAllocReq->tft.pres == TRUE)
    {
        bearAllocReq->tft.pres           = data->tft.pres;
-       bearAllocReq->tft.len            = data->tft.len;       
-       bearAllocReq->tft.opCode         = data->tft.opCode;    
-       bearAllocReq->tft.noOfPfs        = data->tft.noOfPfs;   
-       bearAllocReq->tft.eBit           = data->tft.eBit;       
-       bearAllocReq->tft.noOfParams     = data->tft.noOfParams; 
+       bearAllocReq->tft.len            = data->tft.len;
+       bearAllocReq->tft.opCode         = data->tft.opCode;
+       bearAllocReq->tft.noOfPfs        = data->tft.noOfPfs;
+       bearAllocReq->tft.eBit           = data->tft.eBit;
+       bearAllocReq->tft.noOfParams     = data->tft.noOfParams;
 
       bearAllocReq->tft.noOfPfs = data->tft.noOfPfs;
       for( idx = 0 ; idx < bearAllocReq->tft.noOfPfs ; idx++)
       {
          bearAllocReq->tft.pfList[idx].pres = TRUE;
-         bearAllocReq->tft.pfList[idx].id =    data->tft.pfList[idx].id;    
+         bearAllocReq->tft.pfList[idx].id =    data->tft.pfList[idx].id;
          bearAllocReq->tft.pfList[idx].dir =   data->tft.pfList[idx].dir;
-         bearAllocReq->tft.pfList[idx].preced = data->tft.pfList[idx].preced;     
-         bearAllocReq->tft.pfList[idx].len =    data->tft.pfList[idx].len; 
+         bearAllocReq->tft.pfList[idx].preced = data->tft.pfList[idx].preced;
+         bearAllocReq->tft.pfList[idx].len =    data->tft.pfList[idx].len;
          bearAllocReq->tft.pfList[idx].ipv4.pres =  data->tft.pfList[idx].ipv4.pres;
          if(bearAllocReq->tft.pfList[idx].ipv4.pres == TRUE)
-         { 
+         {
             cmMemcpy((U8 *)&bearAllocReq->tft.pfList[idx].ipv4.ip4, \
                (U8 *)data->tft.pfList[idx].ipv4.ip4,CM_ESM_IPV4_SIZE);
             bearAllocReq->tft.pfList[idx].ipv4Mask = data->tft.pfList[idx].ipv4Mask;
          }
          if(bearAllocReq->tft.pfList[idx].ipv6.pres == TRUE)
-         { 
+         {
             cmMemcpy((U8 *)&bearAllocReq->tft.pfList[idx].ipv6.ip6, \
                (U8 *)data->tft.pfList[idx].ipv6.ip6,CM_ESM_IPV6_SIZE);
          }
@@ -2615,11 +2615,11 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
          }
          if(data->tft.pfList[idx].localPort.pres)
          {
-            bearAllocReq->tft.pfList[idx].localPort.pres        =  data->tft.pfList[idx].localPort.pres; 
+            bearAllocReq->tft.pfList[idx].localPort.pres        =  data->tft.pfList[idx].localPort.pres;
             bearAllocReq->tft.pfList[idx].localPort.port        =  data->tft.pfList[idx].localPort.port;
          }
          if(data->tft.pfList[idx].remotePort.pres)
-         { 
+         {
             bearAllocReq->tft.pfList[idx].remotePort.pres       =  data->tft.pfList[idx].remotePort.pres;
             bearAllocReq->tft.pfList[idx].remotePort.port       =  data->tft.pfList[idx].remotePort.port;
          }
@@ -2636,10 +2636,10 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
             bearAllocReq->tft.pfList[idx].remPortRange.rangeLow  =  \
                data->tft.pfList[idx].remPortRange.rangeLow;
              bearAllocReq->tft.pfList[idx].remPortRange.rangeHigh   =\
-               data->tft.pfList[idx].remPortRange.rangeHigh; 
+               data->tft.pfList[idx].remPortRange.rangeHigh;
          }
          if(data->tft.pfList[idx].secParam.pres)
-         { 
+         {
             bearAllocReq->tft.pfList[idx].secParam.pres  =  data->tft.pfList[idx].secParam.pres;
             cmMemcpy((U8 *)&bearAllocReq->tft.pfList[idx].secParam.params, \
                (U8 *)data->tft.pfList[idx].secParam.params, CM_ESM_IP_SEC_SIZE);
@@ -2647,11 +2647,11 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
          if(data->tft.pfList[idx].tos.pres)
          {
             bearAllocReq->tft.pfList[idx].tos.pres       = data->tft.pfList[idx].tos.pres;
-            bearAllocReq->tft.pfList[idx].tos.tos        = data->tft.pfList[idx].tos.tos; 
-            bearAllocReq->tft.pfList[idx].tos.mask       = data->tft.pfList[idx].tos.mask; 
+            bearAllocReq->tft.pfList[idx].tos.tos        = data->tft.pfList[idx].tos.tos;
+            bearAllocReq->tft.pfList[idx].tos.mask       = data->tft.pfList[idx].tos.mask;
          }
          if(data->tft.pfList[idx].flowLabel.pres)
-         { 
+         {
             bearAllocReq->tft.pfList[idx].flowLabel.pres = data->tft.pfList[idx].flowLabel.pres;
             cmMemcpy((U8 *)&bearAllocReq->tft.pfList[idx].flowLabel.buf, \
                (U8 *)data->tft.pfList[idx].flowLabel.buf,CM_ESM_IPV6_FLOW_LABEL_SIZE);
@@ -2661,21 +2661,21 @@ PUBLIC S16 handleUeResAllocReq(ueBearerAllocReq_t *data)
       for( idx = 0 ; idx < bearAllocReq->tft.noOfParams ; idx++)
       {
          bearAllocReq->tft.params[idx].len      = data->tft.params[idx].len;
-         bearAllocReq->tft.params[idx].paramType = data->tft.params[idx].paramType; 
+         bearAllocReq->tft.params[idx].paramType = data->tft.params[idx].paramType;
           cmMemcpy((U8 *)&bearAllocReq->tft.params[idx].buf, \
             (U8 *)data->tft.params[idx].buf,CM_ESM_TFT_MAX_PARAM_BUF);
       }
    }
    fwSendToUeApp(uetMsg);
    FW_LOG_EXITFN(fwCb, ROK);
-}   
+}
 
 /*
  *
- *   Fun:   handleUeDeActvBerAcc 
+ *   Fun:   handleUeDeActvBerAcc
  *
- *   Desc:  This function is used to handle Attach request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Attach request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -2707,10 +2707,10 @@ PRIVATE S16 handleUeDeActvBerAcc(UeDeActvBearCtxtAcc_t* data)
 }
 /*
  *
- *   Fun:   handleUeActvDedBerAcc 
+ *   Fun:   handleUeActvDedBerAcc
  *
- *   Desc:  This function is used to handle Attach request 
- *          from Test Controller 
+ *   Desc:  This function is used to handle Attach request
+ *          from Test Controller
  *
  *   Ret:   None
  *
@@ -2745,7 +2745,7 @@ PRIVATE S16 handleUeActvDedBerAcc(UeActDedBearCtxtAcc_t* data)
 
 /*
  *
- *   Fun:   handleUeActvDedBerRej 
+ *   Fun:   handleUeActvDedBerRej
  *
  *
  *   Ret:   None
@@ -2776,7 +2776,7 @@ PRIVATE S16 handleUeActvDedBerRej(UeActDedBearCtxtRej_t* data)
 
    fwSendToUeApp(uetMsg);
    FW_LOG_EXITFN(fwCb, ROK);
-}   
+}
 
 /*
  *
@@ -2840,17 +2840,17 @@ PRIVATE S16 handleSctpShutdownReq(Void)
 }
 
 /*
- * 
+ *
  *   Fun:   handleUeNasNonDelivery
- * 
- *   Desc:  This function is used to handle the Nas non delivery 
- * 
+ *
+ *   Desc:  This function is used to handle the Nas non delivery
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handleUeNasNonDelivery(UeNasNonDel* data)
 {
@@ -2860,10 +2860,10 @@ PUBLIC Void handleUeNasNonDelivery(UeNasNonDel* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -2881,17 +2881,17 @@ PUBLIC Void handleUeNasNonDelivery(UeNasNonDel* data)
    RETVOID;
 }
 /*
- * 
- *   Fun:   handleUeInitCtxtSetupFail 
- * 
- *   Desc:  This function is used to handle the Initial Context Setup Failure  
- * 
+ *
+ *   Fun:   handleUeInitCtxtSetupFail
+ *
+ *   Desc:  This function is used to handle the Initial Context Setup Failure
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PUBLIC Void handleUeInitCtxtSetupFail(ueInitCtxtSetupFail* data)
 {
@@ -2901,10 +2901,10 @@ PUBLIC Void handleUeInitCtxtSetupFail(ueInitCtxtSetupFail* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -2922,17 +2922,17 @@ PUBLIC Void handleUeInitCtxtSetupFail(ueInitCtxtSetupFail* data)
    RETVOID;
 }
 /*
- * 
- *   Fun:   handleDropUeInitCtxtSetupReq 
- * 
+ *
+ *   Fun:   handleDropUeInitCtxtSetupReq
+ *
  *   Desc:  This function is used to handle  Drop Initial Context Setup Request
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleDropUeInitCtxtSetupReq(UeDropInitCtxtSetup* data)
 {
@@ -2942,10 +2942,10 @@ PRIVATE Void handleDropUeInitCtxtSetupReq(UeDropInitCtxtSetup* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -2962,17 +2962,17 @@ PRIVATE Void handleDropUeInitCtxtSetupReq(UeDropInitCtxtSetup* data)
    RETVOID;
 }
 /*
- * 
- *   Fun:   handleDelayUeCtxtRelCmp 
- * 
+ *
+ *   Fun:   handleDelayUeCtxtRelCmp
+ *
  *   Desc:  This function is used to handle  Delay Initial Context Setup Response
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleDelayUeCtxtRelCmp(UeDelayUeCtxtRelCmp* data)
 {
@@ -2982,10 +2982,10 @@ PRIVATE Void handleDelayUeCtxtRelCmp(UeDelayUeCtxtRelCmp* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -3002,17 +3002,17 @@ PRIVATE Void handleDelayUeCtxtRelCmp(UeDelayUeCtxtRelCmp* data)
    RETVOID;
 }
 /*
- * 
- *   Fun:   handleDelayUeInitCtxtSetupRsp 
- * 
+ *
+ *   Fun:   handleDelayUeInitCtxtSetupRsp
+ *
  *   Desc:  This function is used to handle  Delay Initial Context Setup Response
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleDelayUeInitCtxtSetupRsp(UeDelayInitCtxtSetupRsp* data)
 {
@@ -3022,10 +3022,10 @@ PRIVATE Void handleDelayUeInitCtxtSetupRsp(UeDelayInitCtxtSetupRsp* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -3043,17 +3043,17 @@ PRIVATE Void handleDelayUeInitCtxtSetupRsp(UeDelayInitCtxtSetupRsp* data)
 }
 
 /*
- * 
- *   Fun:   handleSetCtxtRelForICS 
- * 
+ *
+ *   Fun:   handleSetCtxtRelForICS
+ *
  *   Desc:  This function is used to set the Ctxt Rel for ICS
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleSetCtxtRelForICS(UeSetCtxtRelForInitCtxtSetup* data)
 {
@@ -3063,10 +3063,10 @@ PRIVATE Void handleSetCtxtRelForICS(UeSetCtxtRelForInitCtxtSetup* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -3084,18 +3084,18 @@ PRIVATE Void handleSetCtxtRelForICS(UeSetCtxtRelForInitCtxtSetup* data)
    RETVOID;
 }
 /*
- * 
+ *
  *   Fun:   handleEsmInformationRsp
- * 
- *   Desc:  This function is used to handle ESM Information Response 
- *          from Test Controller 
- * 
+ *
+ *   Desc:  This function is used to handle ESM Information Response
+ *          from Test Controller
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
 {
@@ -3108,25 +3108,25 @@ PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
    FW_GET_CB(fwCb);
    FW_LOG_ENTERFN(fwCb);
 
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-            (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(uetMsg), 0,sizeof(UetMessage));              
-   }
-   else
+   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
+            (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK)
    {
-      RETVOID;
-   }   
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-            (Data **)&ueIdCb, (Size) sizeof(UeIdCb)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(ueIdCb), 0,sizeof(UeIdCb));              
+      cmMemset((U8 *)(uetMsg), 0,sizeof(UetMessage));
    }
    else
    {
       RETVOID;
    }
-   
+   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
+            (Data **)&ueIdCb, (Size) sizeof(UeIdCb)) == ROK)
+   {
+      cmMemset((U8 *)(ueIdCb), 0,sizeof(UeIdCb));
+   }
+   else
+   {
+      RETVOID;
+   }
+
    insertUeCb(data->ue_Id, 0, 0, ueIdCb);
    uetMsg->msgType = UE_ESM_INFORMATION_RSP_TYPE;
    ueEsmInfoRsp = &uetMsg->msg.ueEsmInformationRsp;
@@ -3142,18 +3142,18 @@ PRIVATE Void handleEsmInformationRsp(ueEsmInformationRsp_t* data)
 }
 
 /*
- * 
+ *
  *   Fun:   handleMultiEnbConfigReq
- * 
- *   Desc:  This function is used to handle multiple enb config request 
+ *
+ *   Desc:  This function is used to handle multiple enb config request
  *          from Test Controller
- * 
+ *
  *   Ret:   None
- * 
+ *
  *   Notes: None
- * 
+ *
  *   File:  fw_api_int.c
- * 
+ *
  */
 PRIVATE Void handleMultiEnbConfigReq(multiEnbConfigReq_t* data)
 {
@@ -3164,10 +3164,10 @@ PRIVATE Void handleMultiEnbConfigReq(multiEnbConfigReq_t* data)
    FW_LOG_ENTERFN(fwCb);
 
    FW_LOG_DEBUG(fwCb, "Handling Multi Enb config Req msg in TFW");
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool, 
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) 
-   {                                                  
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));              
+   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
+   {
+      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
    }
    else
    {
@@ -3183,6 +3183,8 @@ PRIVATE Void handleMultiEnbConfigReq(multiEnbConfigReq_t* data)
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].cell_id    = data->multiEnbCfgParam[index].cell_id;
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].tac        = data->multiEnbCfgParam[index].tac;
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].enbType    = data->multiEnbCfgParam[index].enbType;
+      msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].plmn_length =
+        data->multiEnbCfgParam[index].plmn_length;
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].plmn_id[0] = data->multiEnbCfgParam[index].plmn_id[0];
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].plmn_id[1] = data->multiEnbCfgParam[index].plmn_id[1];
       msgReq->t.multiEnbConfigReq.nbMultiEnbCfgParam[index].plmn_id[2] = data->multiEnbCfgParam[index].plmn_id[2];

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -10,14 +10,14 @@
 /**********************************************************************
 
      Name:     S1SIM TFW API Interface
-  
+
      Type:     C header file
-  
+
      Desc:     This file contains the structures for Test Framework Interface.
 
      File:     fw_api_int.x
 
-     Prg:      
+     Prg:
 
 **********************************************************************/
 
@@ -260,7 +260,7 @@ typedef enum nbCfg_FailCause
    ENBAPP_CFG_FAILED,
    LSAP_BINDING_FAILED,
    PCAP_CFG_FAILED,
-   UNKNOWN_ERR  
+   UNKNOWN_ERR
 }NbCfgFailCause;
 
 typedef struct fail_Cause
@@ -278,7 +278,7 @@ typedef struct time_ToWaitIe
 
 typedef enum S1Setup_Res
 {
-  S1_SETUP_SUCCESS, 
+  S1_SETUP_SUCCESS,
   S1_SETUP_FAILED
 }S1_setp_Result;
 
@@ -517,7 +517,7 @@ typedef struct Plmn_List
 
 /* security mode command indication optional parameters*/
 
-/* typedef struct nas_Cyph_Cfg,typedef struct nas_Int_prot_cfg and typedef struct kasme 
+/* typedef struct nas_Cyph_Cfg,typedef struct nas_Int_prot_cfg and typedef struct kasme
  * is already defined */
 
 typedef struct Knas_Enc
@@ -627,7 +627,7 @@ typedef struct Shared_Key
 
 /* ue app config typedef structure feilds optional parameters*/
 
-typedef struct Trf_Gen_Ip_Addr 
+typedef struct Trf_Gen_Ip_Addr
 {
    Bool pres;
    U32 trf_gen_ip_addr;
@@ -757,10 +757,10 @@ typedef struct ueSecModeCmdInd
    U8 ue_Id;
    U8 nas_cyp_cfg;
    U8 nas_int_prot_cfg;
-   U8 kasme[MAX_KASME_KEY];  
-   U8 knas_enc[MAX_NAS_ENC_KEY];  
-   U8 knas_int[MAX_NAS_INT_KEY];  
-   U8 knas_Vrfy_Sts;    
+   U8 kasme[MAX_KASME_KEY];
+   U8 knas_enc[MAX_NAS_ENC_KEY];
+   U8 knas_int[MAX_NAS_INT_KEY];
+   U8 knas_Vrfy_Sts;
 }ueSecModeCmdInd_t;
 
 typedef struct ueSecModeComplete
@@ -968,7 +968,7 @@ typedef struct _fwCriticalityDiag
    U32 procedureCriticality;
    FwCriticalityDiag_IE_Lst ieLst;
 }FwCriticalityDiag;
-typedef struct fwNbErrIndMsg 
+typedef struct fwNbErrIndMsg
 {
    U8   isUeAssoc;
    U8   ue_Id;
@@ -979,7 +979,7 @@ typedef struct fwNbErrIndMsg
 typedef struct _pdnConRejInfo
 {
    U8 epsBearerId;
-   U8 cause; 
+   U8 cause;
 }pdnConRejInfo_t;
 
 typedef struct _ue_Pdn_Info
@@ -990,7 +990,7 @@ typedef struct _ue_Pdn_Info
    ue_Esm_ApnAmbr apnAmbr;
 }Ue_Pdn_Info;
 
-typedef struct uepdnConRsp 
+typedef struct uepdnConRsp
 {
    U8 ue_Id;
    U8 status;
@@ -1044,7 +1044,7 @@ typedef struct ueTauReq
    U8 ue_Id;
    ueMtmsi_t ueMtmsi;
    Eps_Updt_Type type;
-   U8 Actv_flag;   
+   U8 Actv_flag;
 }ueTauReq_t;
 
 typedef struct ueTauAccept
@@ -1094,47 +1094,47 @@ typedef struct _ueEsmTftPfIpv6
 typedef struct _ueEsmTftProtIden
 {
    U8    pres;
-   U8           protType;  
+   U8           protType;
 }ue_Esm_Tft_Prot_Iden;
 
 
 typedef struct _ueEsmTftPort
 {
    U8    pres;
-   U16          port;  
+   U16          port;
 }ue_Esm_Tft_Port;
 
 typedef struct _ueEsmTftPortRange
 {
    U8           pres;
-   U16          rangeLow;  
-   U16          rangeHigh;  
+   U16          rangeLow;
+   U16          rangeHigh;
 }ue_Esm_Tft_Port_Range;
 
 typedef struct _ueEsmTftSecParam
 {
    U8          pres;
-   U8          params[UE_ESM_IP_SEC_SIZE];  
+   U8          params[UE_ESM_IP_SEC_SIZE];
 }ue_Esm_Tft_Sec_Param;
 
 typedef struct _ueEsmTftTos
 {
    U8   pres;
-   U8          tos;  
-   U8          mask;  
+   U8          tos;
+   U8          mask;
 }ue_Esm_Tft_Tos;
 
 typedef struct _ueEsmTftIpv6FlowLbl
 {
    U8          pres;
-   U8          buf[UE_ESM_IPV6_FLOW_LABEL_SIZE];  
+   U8          buf[UE_ESM_IPV6_FLOW_LABEL_SIZE];
 }ue_Esm_Tft_Ipv6_FlowLbl;
 
 typedef struct _ueEsmTftPf
 {
-   U8            pres;         /* present or Not*/ 
-   U8                   id;           /* Packet Filter idenntifier*/   
-   U8                   dir;          /* Direction */ 
+   U8            pres;         /* present or Not*/
+   U8                   id;           /* Packet Filter idenntifier*/
+   U8                   dir;          /* Direction */
    U8                   preced;       /* Precedence */
    U8                  len;          /* Length */
    U32                 ipv4Mask;
@@ -1161,18 +1161,18 @@ typedef struct _ueEsmTftParam
 {
    ue_Esm_Tft_Param_Type      paramType;
    U8                     len;
-   U8                     buf [UE_ESM_TFT_MAX_PARAM_BUF]; 
+   U8                     buf [UE_ESM_TFT_MAX_PARAM_BUF];
 }ue_Esm_Tft_Param;
 typedef struct _ueEsmTft
 {
-   U8    pres;                                           /* Present or not */  
-   U8    len;  
+   U8    pres;                                           /* Present or not */
+   U8    len;
    U8    opCode;                             /* TFT Operation Code*/
    U8    eBit ;                                        /* param List presnt */
    U8    noOfPfs;                                      /* No  Of packet Filters */
    U8    noOfParams;                                   /* No Of packet Filters */
    ue_Esm_Tft_Pf  *pfList;  /* Pf List */
-   ue_Esm_Tft_Param      *params;       /* Tft Params */  
+   ue_Esm_Tft_Param      *params;       /* Tft Params */
 }ue_Esm_Tft;
 
 typedef struct ueBearerAllocReq
@@ -1220,7 +1220,7 @@ typedef struct _EsmTxnId
 typedef struct ueActDedBearCtxtReq
 {
    U8                   ue_Id;
-   U8                   bearerId;  
+   U8                   bearerId;
    ue_Esm_Eps_Qos       epsQos;
    ue_Esm_Tft           tft;
    ue_Esm_TxnId         txnId;
@@ -1235,27 +1235,27 @@ typedef struct ueActDedBearCtxtReq
 typedef struct ueActDedBearCtxtAcc
 {
    U8                   ue_Id;
-   U8                   bearerId;  
+   U8                   bearerId;
 }UeActDedBearCtxtAcc_t;
 
 typedef struct ueActDedBearCtxtRej
 {
    U8                   ue_Id;
    U8                   bearerId;
-   U8                   esmCause;  
+   U8                   esmCause;
 }UeActDedBearCtxtRej_t;
 
 typedef struct ueDeActvBearCtxtReq
 {
    U8 ue_Id;
-   U8 bearerId; 
+   U8 bearerId;
    U8 esmCause;
 }UeDeActvBearCtxtReq_t;
 
 typedef struct ueDeActvBearCtxtAcc
 {
    U8 ue_Id;
-   U8 bearerId; 
+   U8 bearerId;
 }UeDeActvBearCtxtAcc_t;
 
 typedef enum
@@ -1267,7 +1267,7 @@ typedef enum
    TFW_CAUSE_MISC
 }NasNonDelCauseType;
 
-typedef enum 
+typedef enum
 {
    TfwCauseRadioNwunspecifiedEnum,
    TfwCauseRadioNwtx2relocoverall_expiryEnum,
@@ -1282,7 +1282,7 @@ typedef enum
    TfwCauseRadioNwcell_not_availableEnum
 }NasNonDelCauseValRadioNw;
 
-typedef enum 
+typedef enum
 {
         SztCauseNasnormal_releaseEnum,
         SztCauseNasauthentication_failureEnum,
@@ -1300,14 +1300,14 @@ typedef struct ueNasNonDel
 {
    U8 ue_Id;
    Bool flag;
-   NasNonDelCauseType causeType;       
+   NasNonDelCauseType causeType;
    U32 causeVal;
 }UeNasNonDel;
 typedef struct ueInitCtxtSetupFail
 {
    U8 ue_Id;
    Bool flag;
-   U8 causeType;       
+   U8 causeType;
    U32 causeVal;
 }ueInitCtxtSetupFail;
 typedef struct ueDropInitCtxtSetup
@@ -1331,7 +1331,7 @@ typedef struct ueDelayUeCtxtRelCmp
 typedef struct ueSetCtxtRelForInitCtxtSetup
 {
    U8 ue_Id;
-   U8 causeType;       
+   U8 causeType;
    U32 causeVal;
    Bool flag;
 }UeSetCtxtRelForInitCtxtSetup;
@@ -1342,7 +1342,7 @@ typedef struct ueNasNonDelRsp
 
 typedef struct _num_Of_Enbs
 {
-   Bool pres; 
+   Bool pres;
    U8   numOfEnb;
 }num_Of_Enbs_t;
 
@@ -1495,7 +1495,7 @@ typedef struct UeAuthRejInd
 typedef struct UeEmmStatus
 {
    U8 ue_Id;
-   U8 cause;   
+   U8 cause;
 }ueEmmStatus_t;
 
 typedef struct UeEsmInformationReq
@@ -1516,7 +1516,9 @@ typedef struct multiEnbCfgParam
    U32 tac;
    U8 plmn_id[MAX_PLMN_ID];
    U32 enbType;
+   U8  plmn_length;
 }multiEnbCfgParam_t;
+
 typedef struct MultiEnbConfigReq
 {
    U32 numOfEnbs;


### PR DESCRIPTION
## Title
Provided fix for 3 digit and 2 digit PLMN

## Summary
Full description of the PR.
1. Correcting the serving plmn updation in ueCb which was eventually used in Kasme calculation
2. In order to identify the 5 digit pLMN or 6 digit PLMN, previously "0" was used as differentiator, if plmn[5] is zero, that was regarded as 5 digit PLMN, which is incorrect as "0" is also valid PLMN  digit.
To differentiate 5 digit PLMN or 6 digit PLMN, plmn length is passed from test cases
Todo:
Need to test multiple eNB each configured with different PLMN sizes

## Test plan
- Executed 3 digit PLMN and 2 digit PLMN for single and multiple eNB
- Executed s1ap sanity test suite
