### PR TITLE
[enhancement] UL TFT support in S1 SIM

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -471,11 +471,7 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
                tnlInfo->pdnAddr          = ueIpAddr;
                nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
                nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
-               tnlInfo->num_pf = rsp->num_pf;
-               for(num_tft=0; num_tft<tnlInfo->num_pf; num_tft++)
-               {
-	         tnlInfo->tft[num_tft].remotePort = rsp->tft[num_tft].remotePort;
-               }
+               cmMemcpy(tnlInfo->pfList, rsp->pfList, sizeof(rsp->pfList));
                RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
             }
       }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -471,7 +471,13 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
                tnlInfo->pdnAddr          = ueIpAddr;
                nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
                nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
-               cmMemcpy(tnlInfo->pfList, rsp->pfList, sizeof(rsp->pfList));
+               // Fill TFT info
+               if (rsp->noOfPfs)
+               {
+                 tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
+                 tnlInfo->tft.num_pf = rsp->noOfPfs;
+                 cmMemcpy(tnlInfo->tft.pfList, rsp->pfList, sizeof(rsp->pfList));
+               }
                RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
             }
       }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -43,7 +43,7 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup);
 PUBLIC S16 nbDelUeCb(U8 ueId);
 PUBLIC S16 nbUeTnlCreatCfm(U8, U32);
 PUBLIC S16 nbPrcDamUeDelCfm(U8);
-PUBLIC S16 nbCreateUeTunnReq(U8, U32,U8, NbuUeIpInfoRsp*);
+PUBLIC S16 nbCreateUeTunnReq(U8, U32, U8, NbuUeIpInfoRsp *);
 PUBLIC S16 NbEnbUeRelReqHdl(NbUeCntxtRelReq*);
 PUBLIC S16 NbEnbResetReqHdl(NbResetRequest *resetReq);
 /*PUBLIC S16 NbEnbErabRelIndHdl(NbErabRelInd *erabRelInd);*/
@@ -459,10 +459,10 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
                nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
                tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
                // Fill TFT info
-               if (rsp->noOfPfs)
-               {
+               if (rsp->noOfPfs) {
                  tnlInfo->tft.num_pf = rsp->noOfPfs;
-                 cmMemcpy(tnlInfo->tft.pfList, rsp->pfList, sizeof(rsp->pfList));
+                 cmMemcpy(tnlInfo->tft.pfList, rsp->pfList,
+                       sizeof(rsp->pfList));
                }
                RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
             }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -421,54 +421,48 @@ PUBLIC S16 nbPrcDamUeDelCfm(U8 ueId)
    RETVALUE(ret);
 }
 
-PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *rsp)
+PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr, U8 bearerId,
+                             NbuUeIpInfoRsp *rsp)
 {
-   U8 idx       = 0;
-   U8 num_tft   = 0;
-   NbUeCb *ueCb = NULLP;
-   U32 berId = bearerId;
+  U8 idx = 0;
+  U8 num_tft = 0;
+  NbUeCb *ueCb = NULLP;
+  U32 berId = bearerId;
 
-   NbDamTnlInfo   *tnlInfo = NULLP;
-   NbUeTunInfo    *tunInfo = NULLP;
+  NbDamTnlInfo *tnlInfo = NULLP;
+  NbUeTunInfo *tunInfo = NULLP;
 
-   NB_LOG_ENTERFN(&nbCb);
-   if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
-   {
-      RETVALUE(RFAILED);
-   }
+  NB_LOG_ENTERFN(&nbCb);
+  if (ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId), sizeof(U8), 0,
+                             (PTR *)&ueCb))) {
+    RETVALUE(RFAILED);
+  }
 
-   NB_ALLOC_SHAREBLE_BUF(&tnlInfo, sizeof(NbDamTnlInfo));
-   if(tnlInfo != NULLP)
-   {
-      for(idx = 0 ; idx < ueCb->tunnIdx; idx ++)
-      {
-            if ( ROK != (cmHashListFind(&(ueCb->tunnInfo), (U8 *)&(berId),
-                        sizeof(U32),0,(PTR *)&tunInfo)))
-            {    
-               RETVALUE(RFAILED);
-            }    
-            else
-            {
-               tnlInfo->tnlId.drbId      = tunInfo->bearerId;
-               tnlInfo->tnlType          = NB_TNL_NORMAL;
-               tnlInfo->remTeid          = tunInfo->remTeId;
-               tnlInfo->lclTeid          = tunInfo->lclTeId;
-               tnlInfo->pdnAddr          = ueIpAddr;
-               nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
-               nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
-               tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
-               // Fill TFT info
-               if (rsp->noOfPfs) {
-                 tnlInfo->tft.num_pf = rsp->noOfPfs;
-                 cmMemcpy(tnlInfo->tft.pfList, rsp->pfList,
-                       sizeof(rsp->pfList));
-               }
-               RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
-            }
+  NB_ALLOC_SHAREBLE_BUF(&tnlInfo, sizeof(NbDamTnlInfo));
+  if (tnlInfo != NULLP) {
+    for (idx = 0; idx < ueCb->tunnIdx; idx++) {
+      if (ROK != (cmHashListFind(&(ueCb->tunnInfo), (U8 *)&(berId), sizeof(U32),
+                                 0, (PTR *)&tunInfo))) {
+        RETVALUE(RFAILED);
+      } else {
+        tnlInfo->tnlId.drbId = tunInfo->bearerId;
+        tnlInfo->tnlType = NB_TNL_NORMAL;
+        tnlInfo->remTeid = tunInfo->remTeId;
+        tnlInfo->lclTeid = tunInfo->lclTeId;
+        tnlInfo->pdnAddr = ueIpAddr;
+        nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
+        nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
+        tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
+        // Fill TFT info
+        if (rsp->noOfPfs) {
+          tnlInfo->tft.num_pf = rsp->noOfPfs;
+          cmMemcpy(tnlInfo->tft.pfList, rsp->pfList, sizeof(rsp->pfList));
+        }
+        RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
       }
-   }
-   RETVALUE(RFAILED);
+    }
+  }
+  RETVALUE(RFAILED);
 }
 
 PUBLIC S16 nbDelUeCb(U8 ueId)

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -43,7 +43,7 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup);
 PUBLIC S16 nbDelUeCb(U8 ueId);
 PUBLIC S16 nbUeTnlCreatCfm(U8, U32);
 PUBLIC S16 nbPrcDamUeDelCfm(U8);
-PUBLIC S16 nbCreateUeTunnReq(U8, U32,U8);
+PUBLIC S16 nbCreateUeTunnReq(U8, U32,U8, NbuUeIpInfoRsp*);
 PUBLIC S16 NbEnbUeRelReqHdl(NbUeCntxtRelReq*);
 PUBLIC S16 NbEnbResetReqHdl(NbResetRequest *resetReq);
 /*PUBLIC S16 NbEnbErabRelIndHdl(NbErabRelInd *erabRelInd);*/
@@ -421,9 +421,10 @@ PUBLIC S16 nbPrcDamUeDelCfm(U8 ueId)
    RETVALUE(ret);
 }
 
-PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId)
+PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *rsp)
 {
    U8 idx       = 0;
+   U8 num_tft   = 0;
    NbUeCb *ueCb = NULLP;
    U32 berId = bearerId;
 
@@ -470,6 +471,11 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId)
                tnlInfo->pdnAddr          = ueIpAddr;
                nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
                nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
+               tnlInfo->num_pf = rsp->num_pf;
+               for(num_tft=0; num_tft<tnlInfo->num_pf; num_tft++)
+               {
+	         tnlInfo->tft[num_tft].remotePort = rsp->tft[num_tft].remotePort;
+               }
                RETVALUE(nbIfmDamTnlCreatReq(tnlInfo));
             }
       }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -432,16 +432,6 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
    NbUeTunInfo    *tunInfo = NULLP;
 
    NB_LOG_ENTERFN(&nbCb);
-   #if 0 
-   for(idx = 0; nbCb.ueCbLst[idx] != NULLP ; idx++)
-   {
-      if(nbCb.ueCbLst[idx]->ueId == ueId)
-      {
-         ueCb = nbCb.ueCbLst[idx];
-         break;
-      }
-   }
-   #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
       sizeof(U8),0,(PTR *)&ueCb)))
    {
@@ -453,15 +443,11 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
    {
       for(idx = 0 ; idx < ueCb->tunnIdx; idx ++)
       {
-#if 0
-         if(bearerId == ueCb->tunnInfo[idx]->bearerId)
-#else
             if ( ROK != (cmHashListFind(&(ueCb->tunnInfo), (U8 *)&(berId),
                         sizeof(U32),0,(PTR *)&tunInfo)))
             {    
                RETVALUE(RFAILED);
             }    
-#endif
             else
             {
                tnlInfo->tnlId.drbId      = tunInfo->bearerId;

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -471,10 +471,10 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr,U8 bearerId, NbuUeIpInfoRsp *
                tnlInfo->pdnAddr          = ueIpAddr;
                nbCpyCmTptAddr(&tnlInfo->dstAddr, &(tunInfo->sgwAddr));
                nbCpyCmTptAddr(&tnlInfo->srcAddr, &(nbCb.datAppAddr));
+               tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
                // Fill TFT info
                if (rsp->noOfPfs)
                {
-                 tnlInfo->tft.lnkEpsBearId = rsp->lnkEpsBearId;
                  tnlInfo->tft.num_pf = rsp->noOfPfs;
                  cmMemcpy(tnlInfo->tft.pfList, rsp->pfList, sizeof(rsp->pfList));
                }

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -284,7 +284,6 @@ typedef struct _nbUeTunInfo
    U32       lclTeId;
    U32       remTeId;
    U32       bearerId;
-   U16       remotePort;
    CmTptAddr sgwAddr;
 }NbUeTunInfo;
 

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -280,11 +280,11 @@ typedef struct _nbS1ConnCb
 
 typedef struct _nbUeTunInfo
 {
-   CmHashListEnt             ueHashEnt;
-   U32       lclTeId;
-   U32       remTeId;
-   U32       bearerId;
-   CmTptAddr sgwAddr;
+  CmHashListEnt  ueHashEnt;
+  U32            lclTeId;
+  U32            remTeId;
+  U32            bearerId;
+  CmTptAddr      sgwAddr;
 }NbUeTunInfo;
 
 struct _nbUeCb 

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -283,7 +283,8 @@ typedef struct _nbUeTunInfo
    CmHashListEnt             ueHashEnt;
    U32       lclTeId;
    U32       remTeId;
-   U32        bearerId;
+   U32       bearerId;
+   U16       remotePort;
    CmTptAddr sgwAddr;
 }NbUeTunInfo;
 

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -33,7 +33,7 @@
 #include "nb_dam_ifm_app.h" 
 #include "nb_utils.h"
 #include "nb_log.h"
-#include "nb_traffic_handler.x" 
+#include "nb_traffic_handler.x"
 #include "tft.h"
 
 EXTERN S16 cmPkUeDelCfm(Pst*, U8);
@@ -57,7 +57,7 @@ PUBLIC S16 nbDamEgtpDatInd(Pst*, EgtUEvnt*);
 /* Default Interface type while adding the tunnel at GTP*/
 #define NB_DAM_MAX_DRB_TNLS  3
 /* Incoming packet size to be read 20 bytes IP hdr + src port + dest port */
-#define NB_PACKET_SIZE 24
+#define NB_PACKET_SIZE 4
 
 PUBLIC NbDamCb   nbDamCb;
 /** @brief This function is responsible for starting the inactivity timer.
@@ -470,7 +470,7 @@ PRIVATE S16 nbDamAddUe(NbDamUeCb **ueCb, U8 ueId)
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbSortAndAddPf(NbPdnCb *pdnCb, NbPktFilterList *tftPf) 
+PRIVATE S16 nbSortAndAddPf(NbPdnCb *pdnCb, NbPktFilterList *tftPf)
 {
   NbPktFilterList *temp_pf = NULLP;
   CmLList *current = NULLP;
@@ -513,7 +513,7 @@ PRIVATE S16 nbSortAndAddPf(NbPdnCb *pdnCb, NbPktFilterList *tftPf)
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbAddPfs(NbPdnCb *pdnCb, NbDamTnlInfo *tnlInfo) 
+PRIVATE S16 nbAddPfs(NbPdnCb *pdnCb, NbDamTnlInfo *tnlInfo)
 {
   U8 presence_mask = 0;
   NbPktFilterList *tftPf = NULL;
@@ -579,7 +579,7 @@ PRIVATE S16 nbAddPfs(NbPdnCb *pdnCb, NbDamTnlInfo *tnlInfo)
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbAddPdnCb(NbDamUeCb *ueCb, NbDamTnlInfo *tnlInfo) 
+PRIVATE S16 nbAddPdnCb(NbDamUeCb *ueCb, NbDamTnlInfo *tnlInfo)
 {
   NbPdnCb *pdnCb = NULL;
   NbPktFilterList *NbPf = NULL;
@@ -731,17 +731,17 @@ NbDamTnlInfo                 *tnlInfo
    NB_ALLOC(&(ipInfo), sizeof(NbIpInfo));
    ipInfo->pdnAddr = tnlInfo->pdnAddr;
    ipInfo->drbId = rbId;
-   NB_LOG_DEBUG(&nbCb, "Successfully created PdnCb\n"); 
+   NB_LOG_DEBUG(&nbCb, "Successfully created PdnCb\n");
 
    if (ROK != cmHashListInsert(&(ueCb->ipInfo), (PTR)ipInfo,
                      (U8 *)&ipInfo->pdnAddr, sizeof(U32)))
-   {   
+   {
       NB_FREE(ueCb, sizeof(NbIpInfo))
       NB_LOG_ERROR(&nbCb, "Failed to Insert ip address into ipInfo");
       RETVALUE(RFAILED);
    }
 
-   tnlCb->locTeId = tnlInfo->lclTeid; 
+   tnlCb->locTeId = tnlInfo->lclTeid;
    tnlCb->remTeid = tnlInfo->remTeid;
    nbCpyCmTptAddr(&(tnlCb->dstAddr), &tnlInfo->dstAddr);
    nbCpyCmTptAddr(&(tnlCb->lclAddr), &tnlInfo->srcAddr);
@@ -888,7 +888,7 @@ U8                           msgType
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf) 
+PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
 {
   MsgLen len = 0;
   NbDamTnlCb *tnl;
@@ -1213,7 +1213,7 @@ PUBLIC Void nbDamUeDelReq
  * @return S16
  *    -#Success : ROK
  */
-PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId) 
+PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId)
 {
   NbPdnCb *pdnCb = NULLP;
   ;
@@ -1808,7 +1808,7 @@ PRIVATE S16 nbDamBndLSap
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbMatchPf(NbPktFilterList *tftPf, NbIpPktFields *ipPktFields) 
+PRIVATE S16 nbMatchPf(NbPktFilterList *tftPf, NbIpPktFields *ipPktFields)
 {
   /* IPv4 remote address*/
   if (tftPf->presence_mask & IPV4_REM_ADDR_PKT_FLTR_MASK) {
@@ -1905,7 +1905,7 @@ PUBLIC S16 nbDamDeInit
    RETVALUE(nbDamDeRegTmr());
 }
 
-PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId) 
+PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
 {
   NbDamUeCb *ueCb = NULLP;
   NbDamUeCb *prevUeCb = NULLP;
@@ -1937,17 +1937,17 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
         temp_pf = (NbPktFilterList *)temp_node->node;
         if (ROK == (nbMatchPf(temp_pf, ipPktFields))) {
           *drbId = temp_pf->drbId;
-          NB_LOG_DEBUG(&nbCb, "Matching bearer id found. ", *drbId);
+          NB_LOG_DEBUG(&nbCb, "Matching packet filter found.\n");
           NB_LOG_DEBUG(&nbCb, "Sending data on dedicated bearer %d\n", *drbId);
           RETVALUE(ueCb);
         }
         CM_LLIST_NEXT_NODE(&pdnCb->tftPfList, temp_node);
       }
 
-      // Since no matching TFT found send packet on default bearer
+      // Since no matching packet filter found send packet on default bearer
       *drbId = pdnCb->lnkEpsBearId;
       NB_LOG_DEBUG(
-          &nbCb, "Sending data on default bearer %d as no matching TFT found\n",
+          &nbCb, "Sending data on default bearer %d as no matching PF found\n",
           *drbId);
       RETVALUE(ueCb);
     }

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -590,7 +590,7 @@ PRIVATE S16 nbAddPdnCb(NbDamUeCb *ueCb, NbDamTnlInfo *tnlInfo)
     if (tnlInfo->tft.num_pf) {
       if (ROK != (nbAddPfs(pdnCb, tnlInfo))) {
         NB_LOG_ERROR(&nbCb, "Failed to add Packet Filters for pdn addr %s",
-              tnlInfo->pdnAddr);
+                     tnlInfo->pdnAddr);
         RETVALUE(RFAILED);
       }
     }
@@ -1202,8 +1202,8 @@ PUBLIC Void nbDamUeDelReq
       RETVOID;
    }
 }
- /** @brief This function is resposible for deleting the packet filter/s for a
-  * bearer. *
+/** @brief This function is resposible for deleting the packet filter/s for a
+ * bearer. *
  * @details
  *
  * Function: nbDeletePf
@@ -1213,22 +1213,24 @@ PUBLIC Void nbDamUeDelReq
  * @return S16
  *    -#Success : ROK
  */
-PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId)
+PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId) 
 {
-  NbPdnCb *pdnCb = NULLP;;
-  NbPdnCb *prevPdnCb = NULLP;;
+  NbPdnCb *pdnCb = NULLP;
+  ;
+  NbPdnCb *prevPdnCb = NULLP;
+  ;
   CmLList *temp_node = NULLP;
   NbPktFilterList *temp_pf = NULLP;
   U8 bearer_found = FALSE;
 
   for (; ((cmHashListGetNext(&(ueCb->pdnCb), (PTR)prevPdnCb, (PTR *)&pdnCb)) ==
-         ROK);) {
+          ROK);) {
     CM_LLIST_FIRST_NODE(&pdnCb->tftPfList, temp_node);
     while (temp_node != NULLP) {
       temp_pf = (NbPktFilterList *)temp_node->node;
       if (temp_pf->drbId == bearerId) {
-        bearer_found = TRUE; 
-        cmLListDelFrm(&pdnCb->tftPfList, temp_node); 
+        bearer_found = TRUE;
+        cmLListDelFrm(&pdnCb->tftPfList, temp_node);
         NB_LOG_DEBUG(&nbCb, "Deleted packet filter for bearer %d", bearerId);
       }
       CM_LLIST_NEXT_NODE(&pdnCb->tftPfList, temp_node);
@@ -1240,7 +1242,7 @@ PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId)
     pdnCb = NULLP;
   }
 }
- 
+
 /** @brief This function is resposible for deleting all the Erab info for the particular ue. *
  * @details
  *
@@ -1294,8 +1296,8 @@ PUBLIC Void nbDamNbErabDelReq
          nbDamDelDrbCb(ueCb, drbCb);
          /* NB_FREE_DATA_APP(drbCb, sizeof(NbDamDrbCb));*/ 
          drbCb = NULLP;
-         /* Remove the corresponding packet filter from the list*/
-         nbDeletePf(ueCb,erabRelReq->erabIdLst[count]);
+         /* Remove the corresponding packet filter from the list */
+         nbDeletePf(ueCb, erabRelReq->erabIdLst[count]);
       }
    }
    else  /* DAM-UE CB is not present */
@@ -1948,8 +1950,8 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
           &nbCb, "Sending data on default bearer %d as no matching TFT found\n",
           *drbId);
       RETVALUE(ueCb);
-    }                       
-    if (ueIpMatchFound) 
+    }
+    if (ueIpMatchFound)
       break;
     prevUeCb = ueCb;
     ueCb = NULLP;
@@ -1985,7 +1987,6 @@ PUBLIC Void nbDamNbTunDelReq
  NbuTunDelReq  *tunDelReq
 )
 {
-   NB_LOG_ERROR(&nbCb,"********** nbDamNbTunDelReq %d\n", tunDelReq->erabId);
    NbDamUeCb *ueCb = NULLP;
    NbDamDrbCb *drbCb = NULLP;
    U8 count = 0;

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -582,7 +582,6 @@ PRIVATE S16 nbAddPfs(NbPdnCb *pdnCb, NbDamTnlInfo *tnlInfo)
 PRIVATE S16 nbAddPdnCb(NbDamUeCb *ueCb, NbDamTnlInfo *tnlInfo)
 {
   NbPdnCb *pdnCb = NULL;
-  NbPktFilterList *NbPf = NULL;
 
   if (ROK == (cmHashListFind(&(ueCb->pdnCb), (U8 *)&(tnlInfo->pdnAddr),
                              sizeof(U32), 0, (PTR *)&pdnCb))) {
@@ -658,7 +657,6 @@ NbDamTnlInfo                 *tnlInfo
    NbDamTnlType    tnlType = tnlInfo->tnlType;
    NbDamDrbCb      *drbCb  = NULLP;
    NbIpInfo        *ipInfo = NULLP;
-   U8 idx = 0;
 
    if (rbId >= NB_DAM_MAX_DRBS)
    {
@@ -894,7 +892,6 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   NbDamTnlCb *tnl;
   NbDamUeCb *ueCb = NULLP;
   U8 ipPkt[NB_PACKET_SIZE] = {0};
-  U8 idx = 0;
   U8 drbId;
   MsgLen ipIdx = 1; // Start from 1st index-DSCP
   NbIpPktFields ipPktFields = {0};
@@ -911,26 +908,21 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   }
 
   /* Fetch ToS or DSCP*/
-  for (idx = 0; idx < 1; idx++) {
-    if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to fetch ToS");
-      SPutMsg(mBuf);
-      RETVALUE(RFAILED);
-    }
-    ipIdx++;
+  U8 idx = 0;
+  if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
+    NB_LOG_ERROR(&nbCb, "Failed to fetch ToS");
+    SPutMsg(mBuf);
+    RETVALUE(RFAILED);
   }
   /* Tos or DSCP*/
   ipPktFields.srvClass = ipPkt[0];
   /* Skip 9 bytes to fetch the protocol ID*/
   ipIdx = 9;
   /* Fetch protocol Id*/
-  for (idx = 0; idx < 1; idx++) {
-    if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to fetch protocol Id");
-      SPutMsg(mBuf);
-      RETVALUE(RFAILED);
-    }
-    ipIdx++;
+  if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
+    NB_LOG_ERROR(&nbCb, "Failed to fetch protocol Id");
+    SPutMsg(mBuf);
+    RETVALUE(RFAILED);
   }
   ipPktFields.proto_id = ipPkt[0];
 
@@ -1797,7 +1789,7 @@ PRIVATE S16 nbDamBndLSap
    RETVALUE (ROK);
 } /* nbBndLSap */
 
-/** @brief This function matches the Packet filters with the ip fileds of the
+/** @brief This function matches the Packet filters with the ip fields of the
  *  rcvd packet
  *
  * Function: nbMatchPf
@@ -1909,7 +1901,6 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
 {
   NbDamUeCb *ueCb = NULLP;
   NbDamUeCb *prevUeCb = NULLP;
-  NbIpInfo *ipInfo = NULLP;
   U8 ueIpMatchFound = 0;
   CmLList *temp_node = NULLP;
   NbPktFilterList *temp_pf = NULLP;

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -908,8 +908,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   }
 
   /* Fetch ToS or DSCP*/
-  U8 idx = 0;
-  if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
+  if ((SExamMsg(&ipPkt[0], mBuf, ipIdx) != ROK)) {
     NB_LOG_ERROR(&nbCb, "Failed to fetch ToS");
     SPutMsg(mBuf);
     RETVALUE(RFAILED);
@@ -919,7 +918,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   /* Skip 9 bytes to fetch the protocol ID*/
   ipIdx = 9;
   /* Fetch protocol Id*/
-  if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
+  if ((SExamMsg(&ipPkt[0], mBuf, ipIdx) != ROK)) {
     NB_LOG_ERROR(&nbCb, "Failed to fetch protocol Id");
     SPutMsg(mBuf);
     RETVALUE(RFAILED);
@@ -928,6 +927,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
 
   /* Skip 12 bytes for Local IPv4 address*/
   ipIdx = 12;
+  U8 idx = 0;
   /* Fetch IPv4 local address*/
   for (idx = 0; idx < 4; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -722,7 +722,7 @@ NbDamTnlInfo                 *tnlInfo
        }
        RETVALUE(RFAILED);
    }
-   /* Add TFT packet filters to ueCb */
+   /* Add TFT packet filters to pdnCb */
    if (ROK != nbAddPdnCb(ueCb, tnlInfo)) {
      NB_LOG_ERROR(&nbCb, "Failed to create pdncb");
      RETVALUE(RFAILED);
@@ -914,11 +914,11 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   /* Fetch ToS or DSCP*/
   for (idx = 0; idx < 1; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch ToS");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
-    ipIdx++;
+    //ipIdx++;
   }
   /* Tos or DSCP*/
   ipPktFields.srvClass = ipPkt[0];
@@ -927,11 +927,11 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   /* Fetch protocol Id*/
   for (idx = 0; idx < 1; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch protocol Id");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
-    ipIdx++;
+    //ipIdx++;
   }
   ipPktFields.proto_id = ipPkt[0];
 
@@ -940,7 +940,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   /* Fetch IPv4 local address*/
   for (idx = 0; idx < 4; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch IPv4 local address");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
@@ -951,12 +951,12 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   ipPktFields.locIpv4Addr =
       (ipPkt[0] << 24) + (ipPkt[1] << 16) + (ipPkt[2] << 8) + ipPkt[3];
 
-  /* Skip 16 bytes for Local IPv4 address*/
+  /* Skip 16 bytes for remote IPv4 address*/
   ipIdx = 16;
   /* Remote IPv4 address*/
   for (idx = 0; idx < 4; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch remote IPv4 address");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
@@ -970,7 +970,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   ipIdx = 20;
   for (idx = 0; idx < 2; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch local port");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
@@ -982,7 +982,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
   ipIdx = 22;
   for (idx = 0; idx < 2; idx++) {
     if ((SExamMsg(&ipPkt[idx], mBuf, ipIdx) != ROK)) {
-      NB_LOG_ERROR(&nbCb, "Failed to get message type");
+      NB_LOG_ERROR(&nbCb, "Failed to fetch remote port");
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
@@ -1909,7 +1909,6 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
   NbDamUeCb *ueCb = NULLP;
   NbDamUeCb *prevUeCb = NULLP;
   NbIpInfo *ipInfo = NULLP;
-  U8 ueIpMatchFound = 0;
   CmLList *temp_node = NULLP;
   NbPktFilterList *temp_pf = NULLP;
   NbPdnCb *pdnCb = NULLP;
@@ -1921,8 +1920,7 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
     if (ROK ==
         (cmHashListFind(&((ueCb)->pdnCb), (U8 *)&(ipPktFields->locIpv4Addr),
                         sizeof(U32), 0, (PTR *)&pdnCb))) {
-      NB_LOG_DEBUG(&nbCb, "pdncb found\n");
-      ueIpMatchFound = TRUE;
+      NB_LOG_DEBUG(&nbCb, "pdncb found for ip %s\n", ipPktFields->locIpv4Addr);
       /* Fetch TFT Packet Filter list*/
       CM_LLIST_FIRST_NODE(&pdnCb->tftPfList, temp_node);
       if (temp_node == NULLP) {
@@ -1950,8 +1948,6 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
           *drbId);
       RETVALUE(ueCb);
     }
-    if (ueIpMatchFound)
-      break;
     prevUeCb = ueCb;
     ueCb = NULLP;
   }

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -806,7 +806,6 @@ NbDamDrbCb                  *drbCb
 )
 {
    NbDamTnlCb *tnlCb = NULLP;
-   NB_LOG_ERROR(&nbCb, "*** nbDamDelDrbCb before nbDamDelTunnelAtGtp\n");
    tnlCb = drbCb->tnlInfo;
    nbDamDelTunnelAtGtp(tnlCb);
    NB_FREE_DATA_APP(tnlCb, sizeof(NbDamTnlCb));
@@ -1921,7 +1920,7 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
     if (ROK ==
         (cmHashListFind(&((ueCb)->pdnCb), (U8 *)&(ipPktFields->locIpv4Addr),
                         sizeof(U32), 0, (PTR *)&pdnCb))) {
-      NB_LOG_DEBUG(&nbCb, "pdncb found for ip %s\n", ipPktFields->locIpv4Addr);
+      NB_LOG_DEBUG(&nbCb, "pdncb found\n");
       ueIpMatchFound = TRUE;
       /* Fetch TFT Packet Filter list*/
       CM_LLIST_FIRST_NODE(&pdnCb->tftPfList, temp_node);

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -918,7 +918,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
-    //ipIdx++;
+    ipIdx++;
   }
   /* Tos or DSCP*/
   ipPktFields.srvClass = ipPkt[0];
@@ -931,7 +931,7 @@ PUBLIC S16 nbDamPcapDatInd(Buffer *mBuf)
       SPutMsg(mBuf);
       RETVALUE(RFAILED);
     }
-    //ipIdx++;
+    ipIdx++;
   }
   ipPktFields.proto_id = ipPkt[0];
 
@@ -1909,6 +1909,7 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
   NbDamUeCb *ueCb = NULLP;
   NbDamUeCb *prevUeCb = NULLP;
   NbIpInfo *ipInfo = NULLP;
+  U8 ueIpMatchFound = 0;
   CmLList *temp_node = NULLP;
   NbPktFilterList *temp_pf = NULLP;
   NbPdnCb *pdnCb = NULLP;
@@ -1921,6 +1922,7 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
         (cmHashListFind(&((ueCb)->pdnCb), (U8 *)&(ipPktFields->locIpv4Addr),
                         sizeof(U32), 0, (PTR *)&pdnCb))) {
       NB_LOG_DEBUG(&nbCb, "pdncb found for ip %s\n", ipPktFields->locIpv4Addr);
+      ueIpMatchFound = TRUE;
       /* Fetch TFT Packet Filter list*/
       CM_LLIST_FIRST_NODE(&pdnCb->tftPfList, temp_node);
       if (temp_node == NULLP) {
@@ -1947,7 +1949,9 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
           &nbCb, "Sending data on default bearer %d as no matching TFT found\n",
           *drbId);
       RETVALUE(ueCb);
-    }
+    }                       
+    if (ueIpMatchFound) 
+      break;
     prevUeCb = ueCb;
     ueCb = NULLP;
   }

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -34,14 +34,14 @@
 #include "nb_utils.h"
 #include "nb_log.h"
 #include "nb_traffic_handler.x" 
-#include "tft.h" 
+#include "tft.h"
 
 EXTERN S16 cmPkUeDelCfm(Pst*, U8);
 PRIVATE S16 nbDamLSapCfg(LnbMngmt *cfg, CmStatus *status);
 PRIVATE S16 nbDamLSapCntrl(LnbCntrl *sapCntrl,CmStatus *status,Elmnt elmnt);
 PRIVATE S16 nbDamBndLSap (NbLiSapCb *sapCb,CmStatus  *status,Elmnt elmnt);
 PRIVATE S16 nbDamUbndLSap (NbLiSapCb  *sapCb);
-PRIVATE  NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId);
+PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId);
 PUBLIC  NbDamUeCb *nbDamGetUe(U8 ueId);
 PUBLIC S16 nbDamEgtpDatInd(Pst*, EgtUEvnt*);
 
@@ -57,7 +57,7 @@ PUBLIC S16 nbDamEgtpDatInd(Pst*, EgtUEvnt*);
 /* Default Interface type while adding the tunnel at GTP*/
 #define NB_DAM_MAX_DRB_TNLS  3
 /* Incoming packet size to be read 20 bytes IP hdr + src port + dest port */
-#define NB_PACKET_SIZE  24
+#define NB_PACKET_SIZE 24
 
 PUBLIC NbDamCb   nbDamCb;
 /** @brief This function is responsible for starting the inactivity timer.
@@ -387,53 +387,47 @@ PUBLIC S16 nbDamDelUe
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbDamAddUe
-(
-NbDamUeCb                    **ueCb,
-U8                           ueId
-)
+PRIVATE S16 nbDamAddUe(NbDamUeCb **ueCb, U8 ueId)
 {
-   NbDamDrbCb tmpDamDrbCb;
-   NbIpInfo tmpDamIpInfo;
-   NbPdnCb tmpPdnCb;
-   NbPdnCb pdnCb;
-   U8 offset  = 0;
-   NB_ALLOC(ueCb, sizeof(NbDamUeCb ));
-   if ((*ueCb) == NULLP)
-   {
-      RETVALUE(RFAILED);
-   }
-   (*ueCb)->ueId       = ueId;
-   (*ueCb)->numDrbs    = 0;
-   (*ueCb)->numTunnels = 0;
+  NbDamDrbCb tmpDamDrbCb;
+  NbIpInfo tmpDamIpInfo;
+  NbPdnCb tmpPdnCb;
+  NbPdnCb pdnCb;
+  U8 offset = 0;
+  NB_ALLOC(ueCb, sizeof(NbDamUeCb));
+  if ((*ueCb) == NULLP) {
+    RETVALUE(RFAILED);
+  }
+  (*ueCb)->ueId = ueId;
+  (*ueCb)->numDrbs = 0;
+  (*ueCb)->numTunnels = 0;
 
-   offset = (U8) ((PTR)&tmpDamDrbCb.ueHashEnt - (PTR)&tmpDamDrbCb);
-   if( ROK != (cmHashListInit(&((*ueCb)->drbs), /* messages */
-                        NB_MAX_HASH_SIZE,     /* HL bins for the msgs */
-                        offset,               /* Offset of HL Entry */
-                        FALSE,                /* Allow dup. keys ? */
-                        CM_HASH_KEYTYPE_ANY,  /* HL key type */
-                        nbCb.init.region,     /* Mem region for HL */
-                        nbCb.init.pool)))      /* Mem pool for HL */
-   {
-      NB_LOG_ERROR(&nbCb,"Failed to initialized DamDrbCb List");
-      NB_FREE(ueCb, sizeof(NbDamUeCb))
-      RETVALUE(RFAILED);
-
-   }
-   offset = (U8) ((PTR)&tmpDamIpInfo.ueHashEnt - (PTR)&tmpDamIpInfo);
-   if( ROK != (cmHashListInit(&((*ueCb)->ipInfo), /* messages */
-                        NB_MAX_HASH_SIZE,     /* HL bins for the msgs */
-                        offset,               /* Offset of HL Entry */
-                        TRUE,                /* Allow dup. keys ? */
-                        CM_HASH_KEYTYPE_ANY,  /* HL key type */
-                        nbCb.init.region,     /* Mem region for HL */
-                        nbCb.init.pool)))      /* Mem pool for HL */
-   {
-      NB_LOG_ERROR(&nbCb,"Failed to initialized IpInfo List");
-      NB_FREE(*ueCb, sizeof(NbDamUeCb))
-      RETVALUE(RFAILED);
-   }
+  offset = (U8)((PTR)&tmpDamDrbCb.ueHashEnt - (PTR)&tmpDamDrbCb);
+  if (ROK != (cmHashListInit(&((*ueCb)->drbs),    /* messages */
+                             NB_MAX_HASH_SIZE,    /* HL bins for the msgs */
+                             offset,              /* Offset of HL Entry */
+                             FALSE,               /* Allow dup. keys ? */
+                             CM_HASH_KEYTYPE_ANY, /* HL key type */
+                             nbCb.init.region,    /* Mem region for HL */
+                             nbCb.init.pool)))    /* Mem pool for HL */
+  {
+    NB_LOG_ERROR(&nbCb, "Failed to initialized DamDrbCb List");
+    NB_FREE(ueCb, sizeof(NbDamUeCb))
+    RETVALUE(RFAILED);
+  }
+  offset = (U8)((PTR)&tmpDamIpInfo.ueHashEnt - (PTR)&tmpDamIpInfo);
+  if (ROK != (cmHashListInit(&((*ueCb)->ipInfo),  /* messages */
+                             NB_MAX_HASH_SIZE,    /* HL bins for the msgs */
+                             offset,              /* Offset of HL Entry */
+                             TRUE,                /* Allow dup. keys ? */
+                             CM_HASH_KEYTYPE_ANY, /* HL key type */
+                             nbCb.init.region,    /* Mem region for HL */
+                             nbCb.init.pool)))    /* Mem pool for HL */
+  {
+    NB_LOG_ERROR(&nbCb, "Failed to initialized IpInfo List");
+    NB_FREE(*ueCb, sizeof(NbDamUeCb))
+    RETVALUE(RFAILED);
+  }
 
   offset = (U8)((PTR)&tmpPdnCb.ueHashEnt - (PTR)&tmpPdnCb);
   if (ROK != (cmHashListInit(&((*ueCb)->pdnCb),   /* messages */
@@ -447,7 +441,7 @@ U8                           ueId
     NB_LOG_ERROR(&nbCb, "Failed to initialized PdnCb List");
     NB_FREE(*ueCb, sizeof(NbDamUeCb))
     RETVALUE(RFAILED);
-  }   
+  }
 
   cmLListInit(&(pdnCb.tftPfList));
   if (ROK != cmHashListInsert(&(nbDamCb.ueCbs), (PTR) * (ueCb),
@@ -456,11 +450,11 @@ U8                           ueId
     NB_FREE(*ueCb, sizeof(NbDamUeCb))
     NB_LOG_ERROR(&nbCb, "Failed to Insert UE into UeDamCbLst");
     RETVALUE(RFAILED);
-  } 
+  }
 
-   cmInitTimers(&(*ueCb)->inactivityTmr, 1);
-   nbDamStartUeInactvTmr(*ueCb);
-   RETVALUE(ROK);
+  cmInitTimers(&(*ueCb)->inactivityTmr, 1);
+  nbDamStartUeInactvTmr(*ueCb);
+  RETVALUE(ROK);
 }
 
 /** @brief This function is responsible for adding the Packet Filters
@@ -812,7 +806,7 @@ NbDamDrbCb                  *drbCb
 )
 {
    NbDamTnlCb *tnlCb = NULLP;
-
+   NB_LOG_ERROR(&nbCb, "*** nbDamDelDrbCb before nbDamDelTunnelAtGtp\n");
    tnlCb = drbCb->tnlInfo;
    nbDamDelTunnelAtGtp(tnlCb);
    NB_FREE_DATA_APP(tnlCb, sizeof(NbDamTnlCb));
@@ -1209,7 +1203,45 @@ PUBLIC Void nbDamUeDelReq
       RETVOID;
    }
 }
+ /** @brief This function is resposible for deleting the packet filter/s for a
+  * bearer. *
+ * @details
+ *
+ * Function: nbDeletePf
+ *
+ * @param[in]  ueCb : Pointer to NbDamUeCb
+ * @param[in]  bearerId  : Bearer Id
+ * @return S16
+ *    -#Success : ROK
+ */
+PUBLIC Void nbDeletePf(NbDamUeCb *ueCb, U8 bearerId)
+{
+  NbPdnCb *pdnCb = NULLP;;
+  NbPdnCb *prevPdnCb = NULLP;;
+  CmLList *temp_node = NULLP;
+  NbPktFilterList *temp_pf = NULLP;
+  U8 bearer_found = FALSE;
 
+  for (; ((cmHashListGetNext(&(ueCb->pdnCb), (PTR)prevPdnCb, (PTR *)&pdnCb)) ==
+         ROK);) {
+    CM_LLIST_FIRST_NODE(&pdnCb->tftPfList, temp_node);
+    while (temp_node != NULLP) {
+      temp_pf = (NbPktFilterList *)temp_node->node;
+      if (temp_pf->drbId == bearerId) {
+        bearer_found = TRUE; 
+        cmLListDelFrm(&pdnCb->tftPfList, temp_node); 
+        NB_LOG_DEBUG(&nbCb, "Deleted packet filter for bearer %d", bearerId);
+      }
+      CM_LLIST_NEXT_NODE(&pdnCb->tftPfList, temp_node);
+    }
+    if (bearer_found) {
+      break;
+    }
+    prevPdnCb = pdnCb;
+    pdnCb = NULLP;
+  }
+}
+ 
 /** @brief This function is resposible for deleting all the Erab info for the particular ue. *
  * @details
  *
@@ -1263,6 +1295,8 @@ PUBLIC Void nbDamNbErabDelReq
          nbDamDelDrbCb(ueCb, drbCb);
          /* NB_FREE_DATA_APP(drbCb, sizeof(NbDamDrbCb));*/ 
          drbCb = NULLP;
+         /* Remove the corresponding packet filter from the list*/
+         nbDeletePf(ueCb,erabRelReq->erabIdLst[count]);
       }
    }
    else  /* DAM-UE CB is not present */
@@ -1952,6 +1986,7 @@ PUBLIC Void nbDamNbTunDelReq
  NbuTunDelReq  *tunDelReq
 )
 {
+   NB_LOG_ERROR(&nbCb,"********** nbDamNbTunDelReq %d\n", tunDelReq->erabId);
    NbDamUeCb *ueCb = NULLP;
    NbDamDrbCb *drbCb = NULLP;
    U8 count = 0;

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -205,9 +205,39 @@ typedef struct nbIpInfo
    CmHashListEnt             ueHashEnt;
    U8    drbId;
    U32   pdnAddr;
-   U8    num_pf;
-   UlTft tft[MAX_TFT_PF];
 }NbIpInfo;
+
+typedef struct {
+  U32 ipv4_addr;
+  U32 ipv4_addr_mask;
+} NbTftIpv4Addr;
+
+typedef struct nbPktFilterList
+{
+   CmLList       link;
+   U8            drbId;
+   U8            dir;             
+   U8            preced;          
+   NbTftIpv4Addr remIpv4Addr;
+   U16           locPort;
+   U16           locPortRangeLow;
+   U16           locPortRangeHigh;
+   U16           remPort;
+   U16           remPortRangeLow;
+   U16           remPortRangeHigh;
+   U8            proto_id;
+   U32           ipsecParamInd;
+   U8            srvClass;
+   // Component presence mask
+   U16           presence_mask;
+} NbPktFilterList; 
+
+typedef struct nbPdnCb
+{
+  U32       pdnAddr;
+  // List of TFT Packet Filters
+  CmLListCp tftPfList;
+} NbPdnCb; 
 
 typedef struct nbDamUeCb
 {
@@ -219,15 +249,10 @@ typedef struct nbDamUeCb
    U8                        dataRcvd;
    U32                       numTunnels;
    U32                       numDrbs;
-#if 0
-   NbDamDrbCb                *drbs[NB_DAM_MAX_DRBS];
-   NbIpInfo                  ipInfo[11];
-   U8                        numIps;
-   U16                       ueIdx;
-#else
-   CmHashListCp               drbs;
-   CmHashListCp               ipInfo;
-#endif
+   CmHashListCp              drbs;
+   CmHashListCp              ipInfo;
+   /*PDN Hash List*/
+   CmHashListCp              pdnCb;
 } NbDamUeCb;
 
 /** 

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -212,45 +212,41 @@ typedef struct {
   U32 ipv4_addr_mask;
 } NbTftIpv4Addr;
 
-typedef struct nbIpPktFields
-{
-   U32           locIpv4Addr;
-   U32           remIpv4Addr;
-   U16           locPort;
-   U16           remPort;
-   U8            proto_id;
-//   U32           ipsecParamInd;
-   U8            srvClass;
-} NbIpPktFields; 
+typedef struct nbIpPktFields {
+  U32 locIpv4Addr;
+  U32 remIpv4Addr;
+  U16 locPort;
+  U16 remPort;
+  U8 proto_id;
+  U8 srvClass;
+} NbIpPktFields;
 
-typedef struct nbPktFilterList
-{
-   CmLList       link;
-   U8            drbId;
-   U8            dir;             
-   U8            preced;          
-   NbTftIpv4Addr remIpv4Addr;
-   U16           locPort;
-   U16           locPortRangeLow;
-   U16           locPortRangeHigh;
-   U16           remPort;
-   U16           remPortRangeLow;
-   U16           remPortRangeHigh;
-   U8            proto_id;
-   U32           ipsecParamInd;
-   U8            srvClass;
-   // Component presence mask
-   U16           presence_mask;
-} NbPktFilterList; 
+typedef struct nbPktFilterList {
+  CmLList link;
+  U8 drbId;
+  U8 dir;
+  U8 preced;
+  NbTftIpv4Addr remIpv4Addr;
+  U16 locPort;
+  U16 locPortRangeLow;
+  U16 locPortRangeHigh;
+  U16 remPort;
+  U16 remPortRangeLow;
+  U16 remPortRangeHigh;
+  U8 proto_id;
+  U32 ipsecParamInd;
+  U8 srvClass;
+  // Component presence mask
+  U16 presence_mask;
+} NbPktFilterList;
 
-typedef struct nbPdnCb
-{
-  CmHashListEnt   ueHashEnt;
-  U32             pdnAddr;
-  U32             lnkEpsBearId;
+typedef struct nbPdnCb {
+  CmHashListEnt ueHashEnt;
+  U32 pdnAddr;
+  U32 lnkEpsBearId;
   // List of TFT Packet Filters
-  CmLListCp       tftPfList;
-} NbPdnCb; 
+  CmLListCp tftPfList;
+} NbPdnCb;
 
 typedef struct nbDamUeCb
 {

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -212,6 +212,17 @@ typedef struct {
   U32 ipv4_addr_mask;
 } NbTftIpv4Addr;
 
+typedef struct nbIpPktFields
+{
+   U32           locIpv4Addr;
+   U32           remIpv4Addr;
+   U16           locPort;
+   U16           remPort;
+   U8            proto_id;
+//   U32           ipsecParamInd;
+   U8            srvClass;
+} NbIpPktFields; 
+
 typedef struct nbPktFilterList
 {
    CmLList       link;
@@ -234,7 +245,9 @@ typedef struct nbPktFilterList
 
 typedef struct nbPdnCb
 {
-  U32       pdnAddr;
+  CmHashListEnt   ueHashEnt;
+  U32             pdnAddr;
+  U32             lnkEpsBearId;
   // List of TFT Packet Filters
   CmLListCp tftPfList;
 } NbPdnCb; 

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -249,7 +249,7 @@ typedef struct nbPdnCb
   U32             pdnAddr;
   U32             lnkEpsBearId;
   // List of TFT Packet Filters
-  CmLListCp tftPfList;
+  CmLListCp       tftPfList;
 } NbPdnCb; 
 
 typedef struct nbDamUeCb

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -213,13 +213,13 @@ typedef struct nbIpInfo
  * @details These are the structure members
  * - U32        ipv4_addr      IPv4 address
  * - U32        ipv4_addr_mask IPv4 address mask
- */ 
+ */
 typedef struct {
   U32 ipv4_addr;
   U32 ipv4_addr_mask;
 } NbTftIpv4Addr;
 
-/** 
+/**
  * @brief This structure contains IP packet information
  *
  * @details These are the structure members
@@ -229,7 +229,7 @@ typedef struct {
  * - U16           remPort          Single remote port
  * - U8            proto_id         Protocol type(TCP/UDP)
  * - U8            srvClass         Type Of service(ToS)
- */ 
+ */
 typedef struct nbIpPktFields {
   U32 locIpv4Addr;
   U32 remIpv4Addr;
@@ -238,8 +238,8 @@ typedef struct nbIpPktFields {
   U8 proto_id;
   U8 srvClass;
 } NbIpPktFields;
- 
-/** 
+
+/**
  * @brief This structure contains Packet filter info
  *
  * @details These are the structure members
@@ -257,7 +257,7 @@ typedef struct nbIpPktFields {
  * - U32           ipsecParamInd    IP security parameter Indication
  * - U8            srvClass         Type Of service(ToS)
  * - U16           presence_mask;   Component precence mask
- */ 
+ */
 typedef struct nbPktFilterList {
   CmLList link;
   U8 drbId;
@@ -275,15 +275,15 @@ typedef struct nbPktFilterList {
   U8 srvClass;
   U16 presence_mask;
 } NbPktFilterList;
- 
-/** 
+
+/**
  * @brief This structure contains PDN information
  *
  * @details These are the structure members
  * - U32          pdnAddr        PDN Address
  * - U32          lnkEpsBearId   default bearer id
  * - CmLListCp    tftPfList      List of packet filters
- */     
+ */
 typedef struct nbPdnCb {
   CmHashListEnt ueHashEnt;
   U32 pdnAddr;
@@ -291,20 +291,19 @@ typedef struct nbPdnCb {
   CmLListCp tftPfList;
 } NbPdnCb;
 
-typedef struct nbDamUeCb
-{
-   CmHashListEnt             ueHashEnt;
-   CmTimer                   inactivityTmr;
-   U16                       ueId;
-   U16                       expiryCnt;
-   U8                        ueState;
-   U8                        dataRcvd;
-   U32                       numTunnels;
-   U32                       numDrbs;
-   CmHashListCp              drbs;
-   CmHashListCp              ipInfo;
-   /*PDN Hash List*/
-   CmHashListCp              pdnCb;
+typedef struct nbDamUeCb {
+  CmHashListEnt ueHashEnt;
+  CmTimer inactivityTmr;
+  U16 ueId;
+  U16 expiryCnt;
+  U8 ueState;
+  U8 dataRcvd;
+  U32 numTunnels;
+  U32 numDrbs;
+  CmHashListCp drbs;
+  CmHashListCp ipInfo;
+  /*PDN Hash List*/
+  CmHashListCp pdnCb;
 } NbDamUeCb;
 
 /** 

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -205,6 +205,8 @@ typedef struct nbIpInfo
    CmHashListEnt             ueHashEnt;
    U8    drbId;
    U32   pdnAddr;
+   U8    num_pf;
+   UlTft tft[MAX_TFT_PF];
 }NbIpInfo;
 
 typedef struct nbDamUeCb

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -206,12 +206,30 @@ typedef struct nbIpInfo
    U8    drbId;
    U32   pdnAddr;
 }NbIpInfo;
-
+ 
+/** 
+ * @brief This structure contains IPv4 address
+ *
+ * @details These are the structure members
+ * - U32        ipv4_addr      IPv4 address
+ * - U32        ipv4_addr_mask IPv4 address mask
+ */ 
 typedef struct {
   U32 ipv4_addr;
   U32 ipv4_addr_mask;
 } NbTftIpv4Addr;
 
+/** 
+ * @brief This structure contains IP packet information
+ *
+ * @details These are the structure members
+ * - U32           locIpv4Addr      Local IPv4 address
+ * - U32           remIpv4Addr      Remote IPv4 addr
+ * - U16           locPort          Single local port
+ * - U16           remPort          Single remote port
+ * - U8            proto_id         Protocol type(TCP/UDP)
+ * - U8            srvClass         Type Of service(ToS)
+ */ 
 typedef struct nbIpPktFields {
   U32 locIpv4Addr;
   U32 remIpv4Addr;
@@ -220,7 +238,26 @@ typedef struct nbIpPktFields {
   U8 proto_id;
   U8 srvClass;
 } NbIpPktFields;
-
+ 
+/** 
+ * @brief This structure contains Packet filter info
+ *
+ * @details These are the structure members
+ * - U8            drbId            bearer id
+ * - U8            dir              UL/DL
+ * - U8            preced           precedence
+ * - NbTftIpv4Addr remIpv4Addr      Remote IPv4 addr
+ * - U16           locPort          Single local port
+ * - U16           locPortRangeLow  Local port range
+ * - U16           locPortRangeHigh Local port range
+ * - U16           remPort          Single remote port
+ * - U16           remPortRangeLow  Remote port range
+ * - U16           remPortRangeHigh Remote port range
+ * - U8            proto_id         Protocol type(TCP/UDP)
+ * - U32           ipsecParamInd    IP security parameter Indication
+ * - U8            srvClass         Type Of service(ToS)
+ * - U16           presence_mask;   Component precence mask
+ */ 
 typedef struct nbPktFilterList {
   CmLList link;
   U8 drbId;
@@ -236,15 +273,21 @@ typedef struct nbPktFilterList {
   U8 proto_id;
   U32 ipsecParamInd;
   U8 srvClass;
-  // Component presence mask
   U16 presence_mask;
 } NbPktFilterList;
-
+ 
+/** 
+ * @brief This structure contains PDN information
+ *
+ * @details These are the structure members
+ * - U32          pdnAddr        PDN Address
+ * - U32          lnkEpsBearId   default bearer id
+ * - CmLListCp    tftPfList      List of packet filters
+ */     
 typedef struct nbPdnCb {
   CmHashListEnt ueHashEnt;
   U32 pdnAddr;
   U32 lnkEpsBearId;
-  // List of TFT Packet Filters
   CmLListCp tftPfList;
 } NbPdnCb;
 

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -206,8 +206,8 @@ typedef struct nbIpInfo
    U8    drbId;
    U32   pdnAddr;
 }NbIpInfo;
- 
-/** 
+
+/**
  * @brief This structure contains IPv4 address
  *
  * @details These are the structure members

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -36,7 +36,7 @@ extern "C" {
 #define EVDAMMODIFYEGTPTUNEL        3
 #define EVTDAMDELEGTPTUNEL          4
 #define EUTXXX 1
-
+#define MAX_TFT_PF 4
 /** @def WR_DAM_CFG_OK 
  * This Macro defines the Configuration Status Success.
  */
@@ -136,6 +136,8 @@ typedef struct NbDamTunInfo
    NbEgtpTeid                remTeid;
    NbEgtpTeid                lclTeid;
    U32                       pdnAddr;
+   U8                        num_pf;
+   UlTft                     tft[MAX_TFT_PF];
 } NbDamTnlInfo;
 
 /**

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -114,6 +114,12 @@ typedef struct nbDamTnlId
    NbDamTnlType              tnlType;
 } NbDamTnlId;
 
+typedef struct nbTft
+{
+  U32    lnkEpsBearId;
+  U8     num_pf;
+  TftPfs pfList[CM_MAX_PKT_FILTERS];
+}NbTft;
 /**
  *@brief This structure contains the DAM Tunnel Information. 
  *
@@ -136,8 +142,7 @@ typedef struct NbDamTunInfo
    NbEgtpTeid                remTeid;
    NbEgtpTeid                lclTeid;
    U32                       pdnAddr;
-   U8                        num_pf;
-   TftPfs                    pfList[CM_MAX_PKT_FILTERS];
+   NbTft                     tft;  
 } NbDamTnlInfo;
 
 /**

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -137,7 +137,7 @@ typedef struct NbDamTunInfo
    NbEgtpTeid                lclTeid;
    U32                       pdnAddr;
    U8                        num_pf;
-   UlTft                     tft[MAX_TFT_PF];
+   TftPfs                    pfList[CM_MAX_PKT_FILTERS];
 } NbDamTnlInfo;
 
 /**

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -114,12 +114,11 @@ typedef struct nbDamTnlId
    NbDamTnlType              tnlType;
 } NbDamTnlId;
 
-typedef struct nbTft
-{
-  U32    lnkEpsBearId;
-  U8     num_pf;
+typedef struct nbTft {
+  U32 lnkEpsBearId;
+  U8 num_pf;
   TftPfs pfList[CM_MAX_PKT_FILTERS];
-}NbTft;
+} NbTft;
 /**
  *@brief This structure contains the DAM Tunnel Information. 
  *
@@ -133,16 +132,15 @@ typedef struct nbTft
  * - WrEgtpTeid     remTeid      Remote TEID.
  * - Bool           isFullCfg    indicate the need for full configuration during HO
  */
-typedef struct NbDamTunInfo
-{
-   NbDamTnlId                tnlId;
-   NbDamTnlType              tnlType;
-   CmTptAddr                 dstAddr;
-   CmTptAddr                 srcAddr;
-   NbEgtpTeid                remTeid;
-   NbEgtpTeid                lclTeid;
-   U32                       pdnAddr;
-   NbTft                     tft;  
+typedef struct NbDamTunInfo {
+  NbDamTnlId tnlId;
+  NbDamTnlType tnlType;
+  CmTptAddr dstAddr;
+  CmTptAddr srcAddr;
+  NbEgtpTeid remTeid;
+  NbEgtpTeid lclTeid;
+  U32 pdnAddr;
+  NbTft tft;
 } NbDamTnlInfo;
 
 /**

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -120,7 +120,7 @@ typedef struct nbTft {
   TftPfs pfList[CM_MAX_PKT_FILTERS];
 } NbTft;
 /**
- *@brief This structure contains the DAM Tunnel Information. 
+ *@brief This structure contains the DAM Tunnel Information.
  *
  *@details These are the structure members
  * - U32            transId      Transaction ID.

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -1313,6 +1313,7 @@ PUBLIC S16 nbProcErabRelCmd
    SztNAS_PDU           *nasPdu = NULLP;
    NbUeCb *ueCb = NULLP;
    NbUeTunInfo *tunInfo = NULLP;
+   NbErabRelReq *erabRelReq = NULLP;
 
    TRC2(nbProcErabRelCmd);
    erabRlsCmd = &s1apErabRlsCmd->pdu.val.initiatingMsg.value.u.sztE_RABRlsCmmd;
@@ -1384,6 +1385,16 @@ PUBLIC S16 nbProcErabRelCmd
        NB_LOG_DEBUG(&nbCb, "Deleted tun info for bearer %d\n", erabRelCmd.erabIdLst[cnt]);
      }
    }
+
+   /* Send message to nb dam to delete the packet filters */
+   NB_ALLOC(&erabRelReq, sizeof(NbErabRelReq));
+   erabRelReq->ueId = ueCb->ueId;
+   erabRelReq->numOfErabIds = numOfErabIdsRlsd;
+
+   NB_ALLOC(&erabRelReq->erabIdLst, erabRelReq->numOfErabIds * sizeof(U8));
+   cmMemcpy(erabRelReq->erabIdLst, erabRelCmd.erabIdLst,
+         erabRelReq->numOfErabIds * sizeof(U8));
+   nbIfmDamErabDelReq((Void *)erabRelReq);
 
    if (erabRelCmd.nasPdu.pres == TRUE) {
    /* Need to send to UeApp */

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -1295,119 +1295,114 @@ PUBLIC S16 nbProcPagingMsg
  *       RFAILED : not able to process the ERAB Release Cmd message due to
  *       memory lack.
  */
-PUBLIC S16 nbProcErabRelCmd
-(
- S1apPdu *s1apErabRlsCmd
-)
+PUBLIC S16 nbProcErabRelCmd(S1apPdu *s1apErabRlsCmd) 
 {
-   S16 retVal = ROK;
-   U16 numComp = 0;
-   U16 cnt = 0;
-   U16 erabCnt = 0;
-   NbErabRelCmd erabRelCmd = {0};
-   SztE_RABRlsCmmd *erabRlsCmd = NULLP;
-   SztProtIE_Field_E_RABRlsCmmdIEs *ie = NULLP;
-   U32 enbUeS1apId = 0;
-   U32 mmeUeS1apId = 0;
-   U8 numOfErabIdsRlsd = 0;
-   SztNAS_PDU           *nasPdu = NULLP;
-   NbUeCb *ueCb = NULLP;
-   NbUeTunInfo *tunInfo = NULLP;
-   NbErabRelReq *erabRelReq = NULLP;
+  S16 retVal = ROK;
+  U16 numComp = 0;
+  U16 cnt = 0;
+  U16 erabCnt = 0;
+  NbErabRelCmd erabRelCmd = {0};
+  SztE_RABRlsCmmd *erabRlsCmd = NULLP;
+  SztProtIE_Field_E_RABRlsCmmdIEs *ie = NULLP;
+  U32 enbUeS1apId = 0;
+  U32 mmeUeS1apId = 0;
+  U8 numOfErabIdsRlsd = 0;
+  SztNAS_PDU *nasPdu = NULLP;
+  NbUeCb *ueCb = NULLP;
+  NbUeTunInfo *tunInfo = NULLP;
+  NbErabRelReq *erabRelReq = NULLP;
 
-   TRC2(nbProcErabRelCmd);
-   erabRlsCmd = &s1apErabRlsCmd->pdu.val.initiatingMsg.value.u.sztE_RABRlsCmmd;
-   numComp = erabRlsCmd->protocolIEs.noComp.val;
+  TRC2(nbProcErabRelCmd);
+  erabRlsCmd = &s1apErabRlsCmd->pdu.val.initiatingMsg.value.u.sztE_RABRlsCmmd;
+  numComp = erabRlsCmd->protocolIEs.noComp.val;
 
-   for(cnt = 0; cnt < numComp; cnt++)
-   {
-      ie = &erabRlsCmd->protocolIEs.member[cnt];
-      switch(ie->id.val)
-      {
-         case Sztid_eNB_UE_S1AP_ID:
-            erabRelCmd.enbUeS1apId = ie->value.u.sztENB_UE_S1AP_ID.val;
-            break;
-         case Sztid_MME_UE_S1AP_ID:
-            erabRelCmd.mmeUeS1apId = ie->value.u.sztMME_UE_S1AP_ID.val;
-            break;
-         case Sztid_E_RABToBeRlsdLst:
-            erabRelCmd.numOfErabIds = ie->value.u.sztE_RABLst.noComp.val;
-            NB_ALLOC(&erabRelCmd.erabIdLst, erabRelCmd.numOfErabIds);
-            for(erabCnt = 0; erabCnt < erabRelCmd.numOfErabIds; erabCnt++)
-            {
-               erabRelCmd.erabIdLst[erabCnt] = ie->value.u.sztE_RABLst.\
-                                                member[erabCnt].value.u.\
-                                                sztE_RABItem.e_RAB_ID.val;
-            }
-            break;
-         case Sztid_uEaggregateMaxBitrate:
-            break;
-         case Sztid_downlinkNASTport:
-            break;
-         case Sztid_NAS_PDU: 
-	    if(ie->value.u.sztNAS_PDU.pres == PRSNT_NODEF){
-
-         erabRelCmd.nasPdu.pres = TRUE;
-         NB_ALLOC(&erabRelCmd.nasPdu.val,
-               ((ie->value.u.sztNAS_PDU.len + 1 ) * sizeof(U8)));
-         erabRelCmd.nasPdu.pres = TRUE;
-	 erabRelCmd.nasPdu.len  = ie->value.u.sztNAS_PDU.len;
-         cmMemcpy((U8 *)erabRelCmd.nasPdu.val, (U8 *)ie->value.u.sztNAS_PDU.val, erabRelCmd.nasPdu.len);
-            }
-            break;
-         default:
-            NB_LOG_ERROR(&nbCb, "Invalid IE.");
-            retVal = RFAILED;
-            break;
+  for (cnt = 0; cnt < numComp; cnt++) {
+    ie = &erabRlsCmd->protocolIEs.member[cnt];
+    switch (ie->id.val) {
+    case Sztid_eNB_UE_S1AP_ID:
+      erabRelCmd.enbUeS1apId = ie->value.u.sztENB_UE_S1AP_ID.val;
+      break;
+    case Sztid_MME_UE_S1AP_ID:
+      erabRelCmd.mmeUeS1apId = ie->value.u.sztMME_UE_S1AP_ID.val;
+      break;
+    case Sztid_E_RABToBeRlsdLst:
+      erabRelCmd.numOfErabIds = ie->value.u.sztE_RABLst.noComp.val;
+      NB_ALLOC(&erabRelCmd.erabIdLst, erabRelCmd.numOfErabIds);
+      for (erabCnt = 0; erabCnt < erabRelCmd.numOfErabIds; erabCnt++) {
+        erabRelCmd.erabIdLst[erabCnt] = ie->value.u.sztE_RABLst.member[erabCnt]
+                                            .value.u.sztE_RABItem.e_RAB_ID.val;
       }
-   }
-   enbUeS1apId = erabRelCmd.enbUeS1apId;
-   mmeUeS1apId = erabRelCmd.mmeUeS1apId;
-   numOfErabIdsRlsd = erabRelCmd.numOfErabIds;
-   
-   /* Get UeCb using enb/mme ue s1ap Ids */
-   /*for(cnt = 0; cnt < nbCb.crntUeIdx; cnt++)
-   {
-   }*/
-   cmHashListFind(&(nbCb.ueCbLst),(U8*)&(enbUeS1apId),sizeof(U8),
-     0,(PTR*)(&ueCb));
-   for(cnt = 0; cnt < numOfErabIdsRlsd; cnt++)
-   {
-     U32 bearerId = erabRelCmd.erabIdLst[cnt];
-     retVal = cmHashListFind(&(ueCb->tunnInfo),(U8*)&(bearerId), sizeof(U32), 0, (PTR*)(&tunInfo));
-     if (tunInfo == NULL)
-     {
-       NB_LOG_ERROR(&nbCb, "Could not find tuninfo \n");
-     }
-     if (tunInfo)
-     {
-       cmHashListDelete(&(ueCb->tunnInfo),(PTR)(tunInfo));
-       NB_LOG_DEBUG(&nbCb, "Deleted tun info for bearer %d\n", erabRelCmd.erabIdLst[cnt]);
-     }
-   }
+      break;
+    case Sztid_uEaggregateMaxBitrate:
+      break;
+    case Sztid_downlinkNASTport:
+      break;
+    case Sztid_NAS_PDU:
+      if (ie->value.u.sztNAS_PDU.pres == PRSNT_NODEF) {
 
-   /* Send message to nb dam to delete the packet filters */
-   NB_ALLOC(&erabRelReq, sizeof(NbErabRelReq));
-   erabRelReq->ueId = ueCb->ueId;
-   erabRelReq->numOfErabIds = numOfErabIdsRlsd;
+        erabRelCmd.nasPdu.pres = TRUE;
+        NB_ALLOC(&erabRelCmd.nasPdu.val,
+                 ((ie->value.u.sztNAS_PDU.len + 1) * sizeof(U8)));
+        erabRelCmd.nasPdu.pres = TRUE;
+        erabRelCmd.nasPdu.len = ie->value.u.sztNAS_PDU.len;
+        cmMemcpy((U8 *)erabRelCmd.nasPdu.val, (U8 *)ie->value.u.sztNAS_PDU.val,
+                 erabRelCmd.nasPdu.len);
+      }
+      break;
+    default:
+      NB_LOG_ERROR(&nbCb, "Invalid IE.");
+      retVal = RFAILED;
+      break;
+    }
+  }
+  enbUeS1apId = erabRelCmd.enbUeS1apId;
+  mmeUeS1apId = erabRelCmd.mmeUeS1apId;
+  numOfErabIdsRlsd = erabRelCmd.numOfErabIds;
 
-   NB_ALLOC(&erabRelReq->erabIdLst, erabRelReq->numOfErabIds * sizeof(U8));
-   cmMemcpy(erabRelReq->erabIdLst, erabRelCmd.erabIdLst,
-         erabRelReq->numOfErabIds * sizeof(U8));
-   nbIfmDamErabDelReq((Void *)erabRelReq);
+  /* Get UeCb using enb/mme ue s1ap Ids */
+  /*for(cnt = 0; cnt < nbCb.crntUeIdx; cnt++)
+  {
+  }*/
+  cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(enbUeS1apId), sizeof(U8), 0,
+                 (PTR *)(&ueCb));
+  for (cnt = 0; cnt < numOfErabIdsRlsd; cnt++) {
+    U32 bearerId = erabRelCmd.erabIdLst[cnt];
+    retVal = cmHashListFind(&(ueCb->tunnInfo), (U8 *)&(bearerId), sizeof(U32),
+                            0, (PTR *)(&tunInfo));
+    if (tunInfo == NULL) {
+      NB_LOG_ERROR(&nbCb, "Could not find tuninfo \n");
+    }
+    if (tunInfo) {
+      cmHashListDelete(&(ueCb->tunnInfo), (PTR)(tunInfo));
+      NB_LOG_DEBUG(&nbCb, "Deleted tun info for bearer %d\n",
+                   erabRelCmd.erabIdLst[cnt]);
+    }
+  }
 
-   if (erabRelCmd.nasPdu.pres == TRUE) {
-   /* Need to send to UeApp */
-     retVal = nbSendErabsRelInfo(&erabRelCmd);
+  /* Send message to nb dam to delete the packet filters */
+  NB_ALLOC(&erabRelReq, sizeof(NbErabRelReq));
+  erabRelReq->ueId = ueCb->ueId;
+  erabRelReq->numOfErabIds = numOfErabIdsRlsd;
 
-   /* Send Erab Rel Rsp message */
-    retVal = nbBuildAndSendErabRelRsp(enbUeS1apId, mmeUeS1apId, numOfErabIdsRlsd, erabRelCmd.erabIdLst, 0, NULL);
-   } else {
-   /* Indicate the TFW about the recieved E-RAB Release command. */
-    nbUiSendErabRelCmdInfoToUser(&erabRelCmd); 
-   }
+  NB_ALLOC(&erabRelReq->erabIdLst, erabRelReq->numOfErabIds * sizeof(U8));
+  cmMemcpy(erabRelReq->erabIdLst, erabRelCmd.erabIdLst,
+           erabRelReq->numOfErabIds * sizeof(U8));
+  nbIfmDamErabDelReq((Void *)erabRelReq);
 
-   RETVALUE(retVal);
+  if (erabRelCmd.nasPdu.pres == TRUE) {
+    /* Need to send to UeApp */
+    retVal = nbSendErabsRelInfo(&erabRelCmd);
+
+    /* Send Erab Rel Rsp message */
+    retVal =
+        nbBuildAndSendErabRelRsp(enbUeS1apId, mmeUeS1apId, numOfErabIdsRlsd,
+                                 erabRelCmd.erabIdLst, 0, NULL);
+  } else {
+    /* Indicate the TFW about the recieved E-RAB Release command. */
+    nbUiSendErabRelCmdInfoToUser(&erabRelCmd);
+  }
+
+  RETVALUE(retVal);
 } /* end of nbProcErabRelCmd */
 
 /*

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -467,23 +467,22 @@ PUBLIC S16 nbS1apFillEutranCgi
    RETVALUE(ROK);
 }
 
-PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
+PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp) 
 {
-   U32 ueIpAddr = 0;
-   U8 ueId;
-   U8 bearerId;
+  U32 ueIpAddr = 0;
+  U8 ueId;
+  U8 bearerId;
 
-   ueId = rsp->ueId;
-   bearerId = rsp->bearerId;
-   cmInetAddr(rsp->IpAddr, &ueIpAddr);
-   ueIpAddr = CM_INET_NTOH_U32(ueIpAddr);
-   if(rsp->berType == DEFAULT_BER)
-   {
-     nbAppCfgrPdnAssignedAddr(ueId, ueIpAddr);
-   }
-   /* set the datrcvd flag for ue */
-   nbDamSetDatFlag(ueId);
-   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr,bearerId, rsp));
+  ueId = rsp->ueId;
+  bearerId = rsp->bearerId;
+  cmInetAddr(rsp->IpAddr, &ueIpAddr);
+  ueIpAddr = CM_INET_NTOH_U32(ueIpAddr);
+  if (rsp->berType == DEFAULT_BER) {
+    nbAppCfgrPdnAssignedAddr(ueId, ueIpAddr);
+  }
+  /* set the datrcvd flag for ue */
+  nbDamSetDatFlag(ueId);
+  RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr, bearerId, rsp));
 }
 
 PUBLIC Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId)

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -23,7 +23,7 @@ EXTERN S16 nbS1apFillEutranCgi(S1apPdu*, SztEUTRAN_CGI*, EnbCb*);
 EXTERN S16 nbS1apFillEutranCgi(S1apPdu*, SztEUTRAN_CGI*);
 #endif
 EXTERN S16 NbHandleInitialUeMsg(NbuInitialUeMsg*);
-EXTERN S16 nbCreateUeTunnReq(U8, U32,U8, NbuUeIpInfoRsp*);
+EXTERN S16 nbCreateUeTunnReq(U8, U32, U8, NbuUeIpInfoRsp *);
 #ifdef MULTI_ENB_SUPPORT
 PRIVATE S16 nbS1apBldInitUePdu(NbUeCb*, NbTai*, TknStrOSXL*, S1apPdu**, U32,
       NbuSTmsi, EnbCb*);

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -467,7 +467,7 @@ PUBLIC S16 nbS1apFillEutranCgi
    RETVALUE(ROK);
 }
 
-PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp) 
+PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
 {
   U32 ueIpAddr = 0;
   U8 ueId;

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -23,7 +23,7 @@ EXTERN S16 nbS1apFillEutranCgi(S1apPdu*, SztEUTRAN_CGI*, EnbCb*);
 EXTERN S16 nbS1apFillEutranCgi(S1apPdu*, SztEUTRAN_CGI*);
 #endif
 EXTERN S16 NbHandleInitialUeMsg(NbuInitialUeMsg*);
-EXTERN S16 nbCreateUeTunnReq(U8, U32,U8);
+EXTERN S16 nbCreateUeTunnReq(U8, U32,U8, NbuUeIpInfoRsp*);
 #ifdef MULTI_ENB_SUPPORT
 PRIVATE S16 nbS1apBldInitUePdu(NbUeCb*, NbTai*, TknStrOSXL*, S1apPdu**, U32,
       NbuSTmsi, EnbCb*);
@@ -483,7 +483,7 @@ PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
    }
    /* set the datrcvd flag for ue */
    nbDamSetDatFlag(ueId);
-   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr,bearerId)); 
+   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr,bearerId, rsp));
 }
 
 PUBLIC Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId)

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -479,7 +479,7 @@ PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
    ueIpAddr = CM_INET_NTOH_U32(ueIpAddr);
    if(rsp->berType == DEFAULT_BER)
    {
-   nbAppCfgrPdnAssignedAddr(ueId, ueIpAddr);
+     nbAppCfgrPdnAssignedAddr(ueId, ueIpAddr);
    }
    /* set the datrcvd flag for ue */
    nbDamSetDatFlag(ueId);

--- a/TestCntlrApp/src/fw_cm/nbu.x
+++ b/TestCntlrApp/src/fw_cm/nbu.x
@@ -20,6 +20,8 @@
      Prg:      
 
 *********************************************************************21*/
+#include "tft.h"
+
 typedef struct _nbuSTmsi
 {
    Bool                      pres;
@@ -175,10 +177,24 @@ typedef enum  _bearerType
  DEDICATED_BER
 }BearerType;
 
-typedef struct _ulTft
+typedef struct _tftPfs
 {
-   U16         remotePort;   /* Remote Port Idemtifier */
-}UlTft;
+  U8    id;              /* Packet Filter identifier*/
+  U8    dir;             /* Direction */
+  U8    preced;          /* Precedence */
+  U32   ipv4Mask;        /* Ipv4 Address mask*/
+  U32   remoteIpv4;     /* Ipv4 Address */
+  U8    protId;          /* Protocol Identifier */
+  U16   localPort;       /* Local  Port Identifier */
+  U16   locPortRangeLow; /* Local port range*/
+  U16   locPortRangeHigh;
+  U16   remotePort;      /* Remote Port Idemtifier */
+  U16   remPortRangeLow; /* Remote port range*/
+  U16   remPortRangeHigh;
+  U32   secParam;        /* Security  Param */
+  U8    tos;             /* Type of Service  Param */
+  U16   presenceMask;    /* Component presence mask*/
+} TftPfs;
 
 typedef struct _nbuUeIpInfoRsp
 {
@@ -186,9 +202,8 @@ typedef struct _nbuUeIpInfoRsp
    U8 bearerId;
    S8 IpAddr[20];
    BearerType berType;
-   U8 num_pf;
-#define MAX_TFT_PF 4
-   UlTft tft[MAX_TFT_PF];
+   U8      noOfPfs;
+   TftPfs  pfList[CM_MAX_PKT_FILTERS];
 }NbuUeIpInfoRsp;
 
 typedef struct _nbuTunDelReq

--- a/TestCntlrApp/src/fw_cm/nbu.x
+++ b/TestCntlrApp/src/fw_cm/nbu.x
@@ -202,6 +202,7 @@ typedef struct _nbuUeIpInfoRsp
    U8 bearerId;
    S8 IpAddr[20];
    BearerType berType;
+   U32     lnkEpsBearId;
    U8      noOfPfs;
    TftPfs  pfList[CM_MAX_PKT_FILTERS];
 }NbuUeIpInfoRsp;

--- a/TestCntlrApp/src/fw_cm/nbu.x
+++ b/TestCntlrApp/src/fw_cm/nbu.x
@@ -175,12 +175,20 @@ typedef enum  _bearerType
  DEDICATED_BER
 }BearerType;
 
+typedef struct _ulTft
+{
+   U16         remotePort;   /* Remote Port Idemtifier */
+}UlTft;
+
 typedef struct _nbuUeIpInfoRsp
 {
    U8 ueId;
    U8 bearerId;
    S8 IpAddr[20];
    BearerType berType;
+   U8 num_pf;
+#define MAX_TFT_PF 4
+   UlTft tft[MAX_TFT_PF];
 }NbuUeIpInfoRsp;
 
 typedef struct _nbuTunDelReq

--- a/TestCntlrApp/src/fw_cm/nbu.x
+++ b/TestCntlrApp/src/fw_cm/nbu.x
@@ -177,35 +177,33 @@ typedef enum  _bearerType
  DEDICATED_BER
 }BearerType;
 
-typedef struct _tftPfs
-{
-  U8    id;              /* Packet Filter identifier*/
-  U8    dir;             /* Direction */
-  U8    preced;          /* Precedence */
-  U32   ipv4Mask;        /* Ipv4 Address mask*/
-  U32   remoteIpv4;     /* Ipv4 Address */
-  U8    protId;          /* Protocol Identifier */
-  U16   localPort;       /* Local  Port Identifier */
-  U16   locPortRangeLow; /* Local port range*/
-  U16   locPortRangeHigh;
-  U16   remotePort;      /* Remote Port Idemtifier */
-  U16   remPortRangeLow; /* Remote port range*/
-  U16   remPortRangeHigh;
-  U32   secParam;        /* Security  Param */
-  U8    tos;             /* Type of Service  Param */
-  U16   presenceMask;    /* Component presence mask*/
+typedef struct _tftPfs {
+  U8 id;               /* Packet Filter identifier*/
+  U8 dir;              /* Direction */
+  U8 preced;           /* Precedence */
+  U32 ipv4Mask;        /* Ipv4 Address mask*/
+  U32 remoteIpv4;      /* Ipv4 Address */
+  U8 protId;           /* Protocol Identifier */
+  U16 localPort;       /* Local  Port Identifier */
+  U16 locPortRangeLow; /* Local port range*/
+  U16 locPortRangeHigh;
+  U16 remotePort;      /* Remote Port Identifier */
+  U16 remPortRangeLow; /* Remote port range*/
+  U16 remPortRangeHigh;
+  U32 secParam;     /* Security  Param */
+  U8 tos;           /* Type of Service  Param */
+  U16 presenceMask; /* Component presence mask*/
 } TftPfs;
 
-typedef struct _nbuUeIpInfoRsp
-{
-   U8 ueId;
-   U8 bearerId;
-   S8 IpAddr[20];
-   BearerType berType;
-   U32     lnkEpsBearId;
-   U8      noOfPfs;
-   TftPfs  pfList[CM_MAX_PKT_FILTERS];
-}NbuUeIpInfoRsp;
+typedef struct _nbuUeIpInfoRsp {
+  U8 ueId;
+  U8 bearerId;
+  S8 IpAddr[20];
+  BearerType berType;
+  U32 lnkEpsBearId;
+  U8 noOfPfs;
+  TftPfs pfList[CM_MAX_PKT_FILTERS];
+} NbuUeIpInfoRsp;
 
 typedef struct _nbuTunDelReq
 {

--- a/TestCntlrApp/src/fw_cm/tft.h
+++ b/TestCntlrApp/src/fw_cm/tft.h
@@ -1,0 +1,17 @@
+/**
+ ** Copyright (c) Facebook, Inc. and its affiliates.
+ ** All rights reserved.
+ **
+ ** This source code is licensed under the BSD-style license found in the
+ ** LICENSE file in the root directory of this source tree.
+ **/
+#define CM_MAX_PKT_FILTERS 10
+
+#define IPV4_REM_ADDR_PKT_FLTR_MASK  0x0001 /* IPv4 remote address type*/
+#define PROTO_ID_PKT_FLTR_MASK       0x0002 /* Protocol id/Nxt header  */
+#define SNGL_LOC_PORT_PKT_FLTR_MASK  0x0004 /* Single local port type  */
+#define LOC_PORT_RNG_PKT_FLTR_MASK   0x0008 /* Local port range type   */
+#define SNGL_REM_PORT_PKT_FLTR_MASK  0x0010 /* Single remote port type */
+#define REM_PORT_RNG_PKT_FLTR_MASK   0x0020 /* Remote port range type  */
+#define SECURITY_PARAM_PKT_FLTR_MASK 0x0040 /* Security parameter index*/
+#define SERV_N_CLASS_PKT_FLTR_MASK   0x0080 /* Type of service/Traffic */

--- a/TestCntlrApp/src/fw_cm/tft.h
+++ b/TestCntlrApp/src/fw_cm/tft.h
@@ -7,11 +7,11 @@
  **/
 #define CM_MAX_PKT_FILTERS 10
 
-#define IPV4_REM_ADDR_PKT_FLTR_MASK  0x0001 /* IPv4 remote address type*/
-#define PROTO_ID_PKT_FLTR_MASK       0x0002 /* Protocol id/Nxt header  */
-#define SNGL_LOC_PORT_PKT_FLTR_MASK  0x0004 /* Single local port type  */
-#define LOC_PORT_RNG_PKT_FLTR_MASK   0x0008 /* Local port range type   */
-#define SNGL_REM_PORT_PKT_FLTR_MASK  0x0010 /* Single remote port type */
-#define REM_PORT_RNG_PKT_FLTR_MASK   0x0020 /* Remote port range type  */
+#define IPV4_REM_ADDR_PKT_FLTR_MASK 0x0001  /* IPv4 remote address type*/
+#define PROTO_ID_PKT_FLTR_MASK 0x0002       /* Protocol id/Nxt header  */
+#define SNGL_LOC_PORT_PKT_FLTR_MASK 0x0004  /* Single local port type  */
+#define LOC_PORT_RNG_PKT_FLTR_MASK 0x0008   /* Local port range type   */
+#define SNGL_REM_PORT_PKT_FLTR_MASK 0x0010  /* Single remote port type */
+#define REM_PORT_RNG_PKT_FLTR_MASK 0x0020   /* Remote port range type  */
 #define SECURITY_PARAM_PKT_FLTR_MASK 0x0040 /* Security parameter index*/
-#define SERV_N_CLASS_PKT_FLTR_MASK   0x0080 /* Type of service/Traffic */
+#define SERV_N_CLASS_PKT_FLTR_MASK 0x0080   /* Type of service/Traffic */

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -176,7 +176,7 @@ PRIVATE Void updateGutiInUeCb(UeCb *ueCb, CmEmmEpsMI *guti);
 PRIVATE S16 compareGutiInUeCb(UeCb *ueCb, CmEmmEpsMI *epsMi);
 PRIVATE Void reverse(U8* str);
 PRIVATE U8* itoa(int num, U8* str, int base);
-PUBLIC Void populateIpInfo(UeCb *ueCb,U8 bearerId, NbuUeIpInfoRsp*);
+PUBLIC Void populateIpInfo(UeCb *ueCb, U8 bearerId, NbuUeIpInfoRsp *);
 PRIVATE S16 ueAppRcvEmmMsg(CmNasEvnt *evnt, U8 emmMsgType, UeCb *ueCb);
 PRIVATE S16 ueAppUtlMovEsmCbTransToBid(UeEsmCb *esmCb, UeCb *ueCb);
 PRIVATE S16 uefillDefEsmInfoToUeCb(UeCb *ueCb, CmNasEvnt*, U8, U8);
@@ -6028,8 +6028,8 @@ PRIVATE U8* itoa(int num, U8* str, int base)
  *
  *       Fun: _fill_pf_comp
  *
- *       Desc: Fill Packet filters 
- * 
+ *       Desc: Fill Packet filters
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -6038,84 +6038,73 @@ PRIVATE U8* itoa(int num, U8* str, int base)
  *
  */
 
-PRIVATE Void _fill_pf_comp 
-(
- U8 idx,
- UeCb *ueCb,
- NbuUeIpInfoRsp  *ueIpInfoRsp
-)
+PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp) 
 {
-  ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[idx-1].tft.noOfPfs;
-  for(U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[idx-1].tft.noOfPfs; pf_idx++) {
-    ueIpInfoRsp->pfList[pf_idx].id = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].id;
-    ueIpInfoRsp->pfList[pf_idx].dir = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].dir;    
-    ueIpInfoRsp->pfList[pf_idx].preced = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].preced;     
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.pres) {
-           ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-             IPV4_REM_ADDR_PKT_FLTR_MASK;
-           ueIpInfoRsp->pfList[pf_idx].remoteIpv4 = \
-             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[0] << 24) + \
-             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[1] << 16) + \
-             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[2] << 8) + \
-             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[3]);
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].protId.pres) {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              PROTO_ID_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].protId = \
-              ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].protId.protType;
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.pres)
-         {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              SNGL_LOC_PORT_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].localPort  = ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.port);
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[idx].remotePort.pres)
-         { 
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              SNGL_REM_PORT_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].remotePort = ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remotePort.port);
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[idx].locPortRange.pres)
-         {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              LOC_PORT_RNG_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].locPortRangeLow =
-               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeLow);
-            ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh =  \
-               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeHigh);
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.pres)
-         {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              REM_PORT_RNG_PKT_FLTR_MASK;
-             ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = \
-               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeLow); 
-             ueIpInfoRsp->pfList[pf_idx].remPortRangeLow =  \
-               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeHigh);
-         } 
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].secParam.pres)
-         {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              SECURITY_PARAM_PKT_FLTR_MASK;
-            cmMemcpy((U8 *)&ueIpInfoRsp->pfList[pf_idx].secParam, \
-               (U8 *)ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].secParam.params, CM_ESM_IP_SEC_SIZE);
-         }
-         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].tos.pres)
-         {
-            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
-              SERV_N_CLASS_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].tos  = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].tos.tos; 
-         }  
+  ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[idx - 1].tft.noOfPfs;
+  for (U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[idx - 1].tft.noOfPfs; pf_idx++) {
+    ueIpInfoRsp->pfList[pf_idx].id =
+        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].id;
+    ueIpInfoRsp->pfList[pf_idx].dir =
+        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].dir;
+    ueIpInfoRsp->pfList[pf_idx].preced =
+        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].preced;
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= IPV4_REM_ADDR_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].remoteIpv4 =
+          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[0] << 24) +
+          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[1] << 16) +
+          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[2] << 8) +
+          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[3]);
     }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].protId.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= PROTO_ID_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].protId =
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].protId.protType;
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].localPort.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= SNGL_LOC_PORT_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].localPort =
+          ntohs(ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].localPort.port);
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[idx].remotePort.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= SNGL_REM_PORT_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].remotePort =
+          ntohs(ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remotePort.port);
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[idx].locPortRange.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= LOC_PORT_RNG_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].locPortRangeLow = ntohs(
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].locPortRange.rangeLow);
+      ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh = ntohs(
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].locPortRange.rangeHigh);
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= REM_PORT_RNG_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.rangeLow);
+      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.rangeHigh);
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].secParam.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= SECURITY_PARAM_PKT_FLTR_MASK;
+      cmMemcpy((U8 *)&ueIpInfoRsp->pfList[pf_idx].secParam,
+               (U8 *)ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].secParam.params,
+               CM_ESM_IP_SEC_SIZE);
+    }
+    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].tos.pres) {
+      ueIpInfoRsp->pfList[pf_idx].presenceMask |= SERV_N_CLASS_PKT_FLTR_MASK;
+      ueIpInfoRsp->pfList[pf_idx].tos =
+          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].tos.tos;
+    }
+  }
 }
+
 /*
  *
  *       Fun: populateIpInfo
  *
- *       Desc: Populates NbuUeIpInfoRsp structure 
- * 
+ *       Desc: Populates NbuUeIpInfoRsp structure
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -6123,49 +6112,41 @@ PRIVATE Void _fill_pf_comp
  *       File:  ue_app.c
  *
  */
-PUBLIC Void populateIpInfo
-(
- UeCb *ueCb,
- U8  bearerId,
- NbuUeIpInfoRsp  *ueIpInfoRsp
-)
+PUBLIC Void populateIpInfo(UeCb *ueCb, U8 bearerId,
+                           NbuUeIpInfoRsp *ueIpInfoRsp) 
 {
-   CmEsmPdnAdd *pdn_addr = NULLP;
-   U8 temp[20] = {0}, itrn = 0, cnt = 0;
-   U8 ip_addr[20] = {0};
-   U32 counter = 0;
-   U8 idx = 0;
-   ueIpInfoRsp->ueId = ueCb->ueId;
-   ueIpInfoRsp->bearerId = bearerId;
+  CmEsmPdnAdd *pdn_addr = NULLP;
+  U8 temp[20] = {0}, itrn = 0, cnt = 0;
+  U8 ip_addr[20] = {0};
+  U32 counter = 0;
+  U8 idx = 0;
+  ueIpInfoRsp->ueId = ueCb->ueId;
+  ueIpInfoRsp->bearerId = bearerId;
 
-   for(idx = 1; idx < UE_APP_MAX_DRBS; idx++)
-   {
-     if (ueCb->drbs[idx] == UE_APP_DRB_INUSE)
-     {
-       if(ueCb->ueRabCb[idx-1].epsBearerId == bearerId)
-       {
-          pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
-          ueIpInfoRsp->berType = ueCb->ueRabCb[idx-1].bearerType;
-          ueIpInfoRsp->lnkEpsBearId = bearerId;
-          _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
-          break;
-        }
+  for (idx = 1; idx < UE_APP_MAX_DRBS; idx++) {
+    if (ueCb->drbs[idx] == UE_APP_DRB_INUSE) {
+      if (ueCb->ueRabCb[idx - 1].epsBearerId == bearerId) {
+        pdn_addr = &ueCb->ueRabCb[idx - 1].pAddr;
+        ueIpInfoRsp->berType = ueCb->ueRabCb[idx - 1].bearerType;
+        ueIpInfoRsp->lnkEpsBearId = bearerId;
+        _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
+        break;
       }
-   }
-   if((pdn_addr != NULLP) && pdn_addr->pres)
-   {
-      for(counter = 0; counter < (pdn_addr->len - 1) ; counter++)
-      {
-         itoa(pdn_addr->addrInfo[counter], temp, 10);
-         for(cnt = 0; (itrn < 20) && (temp[cnt] != '\0') && (cnt < 19); itrn++, cnt++)
-            ip_addr[itrn] = temp[cnt];
-         if(counter != (pdn_addr->len - 2) && (itrn < 20))
-            ip_addr[itrn++] = '.';
-         if(counter == (pdn_addr->len - 2) && (itrn < 20))
-            ip_addr[itrn] = '\0';
-      }
-      strcpy(ueIpInfoRsp->IpAddr, ip_addr);
-   }
+    }
+  }
+  if ((pdn_addr != NULLP) && pdn_addr->pres) {
+    for (counter = 0; counter < (pdn_addr->len - 1); counter++) {
+      itoa(pdn_addr->addrInfo[counter], temp, 10);
+      for (cnt = 0; (itrn < 20) && (temp[cnt] != '\0') && (cnt < 19);
+           itrn++, cnt++)
+        ip_addr[itrn] = temp[cnt];
+      if (counter != (pdn_addr->len - 2) && (itrn < 20))
+        ip_addr[itrn++] = '.';
+      if (counter == (pdn_addr->len - 2) && (itrn < 20))
+        ip_addr[itrn] = '\0';
+    }
+    strcpy(ueIpInfoRsp->IpAddr, ip_addr);
+  }
 }
 
 /*

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6146,6 +6146,7 @@ PUBLIC Void populateIpInfo
        {
           pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
           ueIpInfoRsp->berType = ueCb->ueRabCb[idx-1].bearerType;
+          ueIpInfoRsp->lnkEpsBearId = ueCb->ueRabCb[idx-1].lnkEpsBearId;
           _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
 
           break;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6136,48 +6136,6 @@ PUBLIC Void populateIpInfo(UeCb *ueCb, U8 bearerId,
         ueIpInfoRsp->lnkEpsBearId = bearerId;
         _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
         break;
-=======
-PUBLIC Void populateIpAddrStrFromUeCb
-(
- U8 *temp_ip,
- UeCb *ueCb,
- U8  bearerId,
- BearType *bearerType
-)
-{
-   CmEsmPdnAdd *pdn_addr = NULLP;
-   U8 temp[20] = {0}, i = 0, j = 0;
-   U8 ip_addr[20] = {0};
-   U32 counter = 0;
-   U8 idx = 0;
-   /*pdn_addr = &evnt->m.emmEvnt->u.atchAcc.esmEvnt->m.esmEvnt->u.actReq.\
-    * pAddr; */
-     for(idx = 1; idx < UE_APP_MAX_DRBS; idx++)
-   {
-      if (ueCb->drbs[idx] == UE_APP_DRB_INUSE)
-      {
-        if(ueCb->ueRabCb[idx-1].epsBearerId == bearerId)
-        {
-           pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
-           *bearerType = ueCb->ueRabCb[idx-1].bearerType;
-           break;
-        }
-      }
-   }
-   if((pdn_addr != NULLP) && pdn_addr->pres)
-   {
-      for(counter = 0; counter < (pdn_addr->len - 1) ; counter++)
-      {
-         itoa(pdn_addr->addrInfo[counter], temp, 10);
-         for(j = 0; (i < 20) && (temp[j] != '\0') && (j < 19); i++, j++)
-            ip_addr[i] = temp[j];
-         /*strcat((U8*)ip_addr,(U8*)temp);*/
-         if(counter != (pdn_addr->len - 2) && (i < 20))
-            ip_addr[i++] = '.';
-         /* strcat((U8*)ip_addr,(U8*)".");*/
-         if(counter == (pdn_addr->len - 2) && (i < 20))
-            ip_addr[i] = '\0';
->>>>>>> upstream/master
       }
     }
   }

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -76,6 +76,7 @@
 #include "ue_app.x"
 #include "nbu.x"
 #include "ueAppdbm.x"
+#include "tft.h"
 
 EXTERN UeAppCb gueAppCb;
 
@@ -175,8 +176,7 @@ PRIVATE Void updateGutiInUeCb(UeCb *ueCb, CmEmmEpsMI *guti);
 PRIVATE S16 compareGutiInUeCb(UeCb *ueCb, CmEmmEpsMI *epsMi);
 PRIVATE Void reverse(U8* str);
 PRIVATE U8* itoa(int num, U8* str, int base);
-PUBLIC Void populateIpAddrStrFromUeCb(U8 *temp_ip, UeCb *ueCb,U8 bearerId,
-        BearType *bearerType, NbuUeIpInfoRsp*);
+PUBLIC Void populateIpInfo(UeCb *ueCb,U8 bearerId, NbuUeIpInfoRsp*);
 PRIVATE S16 ueAppRcvEmmMsg(CmNasEvnt *evnt, U8 emmMsgType, UeCb *ueCb);
 PRIVATE S16 ueAppUtlMovEsmCbTransToBid(UeEsmCb *esmCb, UeCb *ueCb);
 PRIVATE S16 uefillDefEsmInfoToUeCb(UeCb *ueCb, CmNasEvnt*, U8, U8);
@@ -6024,9 +6024,9 @@ PRIVATE U8* itoa(int num, U8* str, int base)
    return str;
 }
 
-/*
+ /*
  *
- *       Fun: populateIpAddrStrFromUeCb
+ *       Fun: _fill_pf_comp
  *
  *       Desc: 
  * 
@@ -6037,12 +6037,93 @@ PRIVATE U8* itoa(int num, U8* str, int base)
  *       File:  ue_app.c
  *
  */
-PUBLIC Void populateIpAddrStrFromUeCb
+
+PRIVATE Void _fill_pf_comp 
 (
- U8 *temp_ip,
+ U8 idx,
+ UeCb *ueCb,
+ NbuUeIpInfoRsp  *ueIpInfoRsp
+)
+{
+  ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[idx-1].tft.noOfPfs;
+  for(U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[idx-1].tft.noOfPfs; pf_idx++) {
+    ueIpInfoRsp->pfList[pf_idx].id = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].id;
+    ueIpInfoRsp->pfList[pf_idx].dir = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].dir;    
+    ueIpInfoRsp->pfList[pf_idx].preced = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].preced;     
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.pres) {
+           ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+             IPV4_REM_ADDR_PKT_FLTR_MASK;
+           ueIpInfoRsp->pfList[pf_idx].remoteIpv4 = \
+             ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4;
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].protId.pres) {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              PROTO_ID_PKT_FLTR_MASK;
+            ueIpInfoRsp->pfList[pf_idx].protId = \
+              ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].protId.protType;
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.pres)
+         {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              SNGL_LOC_PORT_PKT_FLTR_MASK;
+            ueIpInfoRsp->pfList[pf_idx].localPort  = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.port;
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[idx].remotePort.pres)
+         { 
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              SNGL_REM_PORT_PKT_FLTR_MASK;
+            ueIpInfoRsp->pfList[pf_idx].remotePort = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remotePort.port;
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[idx].locPortRange.pres)
+         {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              LOC_PORT_RNG_PKT_FLTR_MASK;
+            ueIpInfoRsp->pfList[pf_idx].locPortRangeLow =
+               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeLow;
+            ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh =  \
+               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeHigh;
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.pres)
+         {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              REM_PORT_RNG_PKT_FLTR_MASK;
+             ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = \
+               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeLow; 
+             ueIpInfoRsp->pfList[pf_idx].remPortRangeLow =  \
+               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeHigh;
+         } 
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].secParam.pres)
+         {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              SECURITY_PARAM_PKT_FLTR_MASK;
+            cmMemcpy((U8 *)&ueIpInfoRsp->pfList[pf_idx].secParam, \
+               (U8 *)ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].secParam.params, CM_ESM_IP_SEC_SIZE);
+         }
+         if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].tos.pres)
+         {
+            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
+              SERV_N_CLASS_PKT_FLTR_MASK;
+            ueIpInfoRsp->pfList[pf_idx].tos  = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].tos.tos; 
+         }  
+    }
+}
+/*
+ *
+ *       Fun: populateIpInfo
+ *
+ *       Desc: 
+ * 
+ *       Ret:  ROK - ok; RFAILED - failed
+ *
+ *       Notes: none
+ *
+ *       File:  ue_app.c
+ *
+ */
+PUBLIC Void populateIpInfo
+(
  UeCb *ueCb,
  U8  bearerId,
- BearType *bearerType,
  NbuUeIpInfoRsp  *ueIpInfoRsp
 )
 {
@@ -6051,32 +6132,26 @@ PUBLIC Void populateIpAddrStrFromUeCb
    U8 ip_addr[20] = {0};
    U32 counter = 0;
    U8 idx = 0;
-   U8 pf_idx = 0;
    U8 tft_idx = 0;
    /*pdn_addr = &evnt->m.emmEvnt->u.atchAcc.esmEvnt->m.esmEvnt->u.actReq.\
     * pAddr; */
-     for(idx = 1; idx < UE_APP_MAX_DRBS; idx++)
+   ueIpInfoRsp->ueId = ueCb->ueId;
+   ueIpInfoRsp->bearerId = bearerId;
+
+   for(idx = 1; idx < UE_APP_MAX_DRBS; idx++)
+   {
+     if (ueCb->drbs[idx] == UE_APP_DRB_INUSE)
      {
-      if (ueCb->drbs[idx] == UE_APP_DRB_INUSE)
-      {
-        if(ueCb->ueRabCb[idx-1].epsBearerId == bearerId)
-        {
-           pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
-           *bearerType = ueCb->ueRabCb[idx-1].bearerType;
-           for(pf_idx = 0; pf_idx < ueCb->ueRabCb[idx-1].tft.noOfPfs; pf_idx++)
-           {
-             if (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remotePort.pres)
-             {
-	       ueIpInfoRsp->tft[tft_idx].remotePort =
-                   ntohs(ueCb->ueRabCb[idx-1].tft.pfList[0].remotePort.port);
-               tft_idx++;
-             }
-           }
-           break;
+       if(ueCb->ueRabCb[idx-1].epsBearerId == bearerId)
+       {
+          pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
+          ueIpInfoRsp->berType = ueCb->ueRabCb[idx-1].bearerType;
+          _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
+
+          break;
         }
       }
    }
-   ueIpInfoRsp->num_pf = tft_idx;
    if((pdn_addr != NULLP) && pdn_addr->pres)
    {
       for(counter = 0; counter < (pdn_addr->len - 1) ; counter++)
@@ -6091,7 +6166,8 @@ PUBLIC Void populateIpAddrStrFromUeCb
          if(counter == (pdn_addr->len - 2) && (i < 20))
             ip_addr[i] = '\0';
       }
-      strcpy((char*)temp_ip, (char *)ip_addr);
+      //strcpy((char*)temp_ip, (char *)ip_addr);
+      strcpy(ueIpInfoRsp->IpAddr, ip_addr);
    }
 }
 

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6054,7 +6054,10 @@ PRIVATE Void _fill_pf_comp
            ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
              IPV4_REM_ADDR_PKT_FLTR_MASK;
            ueIpInfoRsp->pfList[pf_idx].remoteIpv4 = \
-             ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4;
+             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[0] << 24) + \
+             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[1] << 16) + \
+             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[2] << 8) + \
+             (ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].ipv4.ip4[3]);
          }
          if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].protId.pres) {
             ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
@@ -6066,31 +6069,31 @@ PRIVATE Void _fill_pf_comp
          {
             ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
               SNGL_LOC_PORT_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].localPort  = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.port;
+            ueIpInfoRsp->pfList[pf_idx].localPort  = ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].localPort.port);
          }
          if(ueCb->ueRabCb[idx-1].tft.pfList[idx].remotePort.pres)
          { 
             ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
               SNGL_REM_PORT_PKT_FLTR_MASK;
-            ueIpInfoRsp->pfList[pf_idx].remotePort = ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remotePort.port;
+            ueIpInfoRsp->pfList[pf_idx].remotePort = ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remotePort.port);
          }
          if(ueCb->ueRabCb[idx-1].tft.pfList[idx].locPortRange.pres)
          {
             ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
               LOC_PORT_RNG_PKT_FLTR_MASK;
             ueIpInfoRsp->pfList[pf_idx].locPortRangeLow =
-               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeLow;
+               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeLow);
             ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh =  \
-               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeHigh;
+               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].locPortRange.rangeHigh);
          }
          if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.pres)
          {
             ueIpInfoRsp->pfList[pf_idx].presenceMask |= \
               REM_PORT_RNG_PKT_FLTR_MASK;
              ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = \
-               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeLow; 
+               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeLow); 
              ueIpInfoRsp->pfList[pf_idx].remPortRangeLow =  \
-               ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeHigh;
+               ntohs(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].remPortRange.rangeHigh);
          } 
          if(ueCb->ueRabCb[idx-1].tft.pfList[pf_idx].secParam.pres)
          {
@@ -6146,9 +6149,8 @@ PUBLIC Void populateIpInfo
        {
           pdn_addr = &ueCb->ueRabCb[idx-1].pAddr;
           ueIpInfoRsp->berType = ueCb->ueRabCb[idx-1].bearerType;
-          ueIpInfoRsp->lnkEpsBearId = ueCb->ueRabCb[idx-1].lnkEpsBearId;
+          ueIpInfoRsp->lnkEpsBearId = bearerId;
           _fill_pf_comp(idx, ueCb, ueIpInfoRsp);
-
           break;
         }
       }

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6135,6 +6135,7 @@ PUBLIC Void populateIpInfo(UeCb *ueCb, U8 bearerId,
       }
     }
   }
+  // Construct IP address
   if ((pdn_addr != NULLP) && pdn_addr->pres) {
     for (counter = 0; counter < (pdn_addr->len - 1); counter++) {
       itoa(pdn_addr->addrInfo[counter], temp, 10);

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6028,7 +6028,7 @@ PRIVATE U8* itoa(int num, U8* str, int base)
  *
  *       Fun: _fill_pf_comp
  *
- *       Desc: 
+ *       Desc: Fill Packet filters 
  * 
  *       Ret:  ROK - ok; RFAILED - failed
  *
@@ -6114,7 +6114,7 @@ PRIVATE Void _fill_pf_comp
  *
  *       Fun: populateIpInfo
  *
- *       Desc: 
+ *       Desc: Populates NbuUeIpInfoRsp structure 
  * 
  *       Ret:  ROK - ok; RFAILED - failed
  *
@@ -6131,13 +6131,10 @@ PUBLIC Void populateIpInfo
 )
 {
    CmEsmPdnAdd *pdn_addr = NULLP;
-   U8 temp[20] = {0}, i = 0, j = 0;
+   U8 temp[20] = {0}, itrn = 0, cnt = 0;
    U8 ip_addr[20] = {0};
    U32 counter = 0;
    U8 idx = 0;
-   U8 tft_idx = 0;
-   /*pdn_addr = &evnt->m.emmEvnt->u.atchAcc.esmEvnt->m.esmEvnt->u.actReq.\
-    * pAddr; */
    ueIpInfoRsp->ueId = ueCb->ueId;
    ueIpInfoRsp->bearerId = bearerId;
 
@@ -6160,16 +6157,13 @@ PUBLIC Void populateIpInfo
       for(counter = 0; counter < (pdn_addr->len - 1) ; counter++)
       {
          itoa(pdn_addr->addrInfo[counter], temp, 10);
-         for(j = 0; (i < 20) && (temp[j] != '\0') && (j < 19); i++, j++)
-            ip_addr[i] = temp[j];
-         /*strcat((U8*)ip_addr,(U8*)temp);*/
-         if(counter != (pdn_addr->len - 2) && (i < 20))
-            ip_addr[i++] = '.';
-         /* strcat((U8*)ip_addr,(U8*)".");*/
-         if(counter == (pdn_addr->len - 2) && (i < 20))
-            ip_addr[i] = '\0';
+         for(cnt = 0; (itrn < 20) && (temp[cnt] != '\0') && (cnt < 19); itrn++, cnt++)
+            ip_addr[itrn] = temp[cnt];
+         if(counter != (pdn_addr->len - 2) && (itrn < 20))
+            ip_addr[itrn++] = '.';
+         if(counter == (pdn_addr->len - 2) && (itrn < 20))
+            ip_addr[itrn] = '\0';
       }
-      //strcpy((char*)temp_ip, (char *)ip_addr);
       strcpy(ueIpInfoRsp->IpAddr, ip_addr);
    }
 }

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6024,7 +6024,7 @@ PRIVATE U8* itoa(int num, U8* str, int base)
    return str;
 }
 
- /*
+/*
  *
  *       Fun: _fill_pf_comp
  *
@@ -6038,13 +6038,12 @@ PRIVATE U8* itoa(int num, U8* str, int base)
  *
  */
 
-PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp) 
+PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp)
 {
-  U8 itrn = idx - 1; 
+  U8 itrn = idx - 1;
   ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[itrn].tft.noOfPfs;
   for (U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[itrn].tft.noOfPfs; pf_idx++) {
-    ueIpInfoRsp->pfList[pf_idx].id =
-        ueCb->ueRabCb[itrn].tft.pfList[pf_idx].id;
+    ueIpInfoRsp->pfList[pf_idx].id = ueCb->ueRabCb[itrn].tft.pfList[pf_idx].id;
     ueIpInfoRsp->pfList[pf_idx].dir =
         ueCb->ueRabCb[itrn].tft.pfList[pf_idx].dir;
     ueIpInfoRsp->pfList[pf_idx].preced =
@@ -6074,17 +6073,17 @@ PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp)
     }
     if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= LOC_PORT_RNG_PKT_FLTR_MASK;
-      ueIpInfoRsp->pfList[pf_idx].locPortRangeLow = ntohs(
-          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeLow);
-      ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh = ntohs(
-          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeHigh);
+      ueIpInfoRsp->pfList[pf_idx].locPortRangeLow =
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeLow);
+      ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh =
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeHigh);
     }
     if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= REM_PORT_RNG_PKT_FLTR_MASK;
-      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
-          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeLow);
-      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
-          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeHigh);
+      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow =
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeLow);
+      ueIpInfoRsp->pfList[pf_idx].remPortRangeLow =
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeHigh);
     }
     if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].secParam.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= SECURITY_PARAM_PKT_FLTR_MASK;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6113,7 +6113,7 @@ PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp)
  *
  */
 PUBLIC Void populateIpInfo(UeCb *ueCb, U8 bearerId,
-                           NbuUeIpInfoRsp *ueIpInfoRsp) 
+                           NbuUeIpInfoRsp *ueIpInfoRsp)
 {
   CmEsmPdnAdd *pdn_addr = NULLP;
   U8 temp[20] = {0}, itrn = 0, cnt = 0;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -6040,61 +6040,62 @@ PRIVATE U8* itoa(int num, U8* str, int base)
 
 PRIVATE Void _fill_pf_comp(U8 idx, UeCb *ueCb, NbuUeIpInfoRsp *ueIpInfoRsp) 
 {
-  ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[idx - 1].tft.noOfPfs;
-  for (U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[idx - 1].tft.noOfPfs; pf_idx++) {
+  U8 itrn = idx - 1; 
+  ueIpInfoRsp->noOfPfs = ueCb->ueRabCb[itrn].tft.noOfPfs;
+  for (U8 pf_idx = 0; pf_idx < ueCb->ueRabCb[itrn].tft.noOfPfs; pf_idx++) {
     ueIpInfoRsp->pfList[pf_idx].id =
-        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].id;
+        ueCb->ueRabCb[itrn].tft.pfList[pf_idx].id;
     ueIpInfoRsp->pfList[pf_idx].dir =
-        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].dir;
+        ueCb->ueRabCb[itrn].tft.pfList[pf_idx].dir;
     ueIpInfoRsp->pfList[pf_idx].preced =
-        ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].preced;
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.pres) {
+        ueCb->ueRabCb[itrn].tft.pfList[pf_idx].preced;
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].ipv4.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= IPV4_REM_ADDR_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].remoteIpv4 =
-          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[0] << 24) +
-          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[1] << 16) +
-          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[2] << 8) +
-          (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].ipv4.ip4[3]);
+          (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].ipv4.ip4[0] << 24) +
+          (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].ipv4.ip4[1] << 16) +
+          (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].ipv4.ip4[2] << 8) +
+          (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].ipv4.ip4[3]);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].protId.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].protId.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= PROTO_ID_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].protId =
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].protId.protType;
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].protId.protType;
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].localPort.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].localPort.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= SNGL_LOC_PORT_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].localPort =
-          ntohs(ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].localPort.port);
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].localPort.port);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[idx].remotePort.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remotePort.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= SNGL_REM_PORT_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].remotePort =
-          ntohs(ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remotePort.port);
+          ntohs(ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remotePort.port);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[idx].locPortRange.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= LOC_PORT_RNG_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].locPortRangeLow = ntohs(
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].locPortRange.rangeLow);
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeLow);
       ueIpInfoRsp->pfList[pf_idx].locPortRangeHigh = ntohs(
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].locPortRange.rangeHigh);
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].locPortRange.rangeHigh);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= REM_PORT_RNG_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.rangeLow);
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeLow);
       ueIpInfoRsp->pfList[pf_idx].remPortRangeLow = ntohs(
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].remPortRange.rangeHigh);
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].remPortRange.rangeHigh);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].secParam.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].secParam.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= SECURITY_PARAM_PKT_FLTR_MASK;
       cmMemcpy((U8 *)&ueIpInfoRsp->pfList[pf_idx].secParam,
-               (U8 *)ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].secParam.params,
+               (U8 *)ueCb->ueRabCb[itrn].tft.pfList[pf_idx].secParam.params,
                CM_ESM_IP_SEC_SIZE);
     }
-    if (ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].tos.pres) {
+    if (ueCb->ueRabCb[itrn].tft.pfList[pf_idx].tos.pres) {
       ueIpInfoRsp->pfList[pf_idx].presenceMask |= SERV_N_CLASS_PKT_FLTR_MASK;
       ueIpInfoRsp->pfList[pf_idx].tos =
-          ueCb->ueRabCb[idx - 1].tft.pfList[pf_idx].tos.tos;
+          ueCb->ueRabCb[itrn].tft.pfList[pf_idx].tos.tos;
     }
   }
 }

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -102,35 +102,21 @@ EXTERN S16 ueUiProcIpInfoReqMsg(UeCb * p_ueCb, U8 bearerId);
 EXTERN S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuUeIpInfoReq(Pst *pst,NbuUeIpInfoReq  *p_ueMsg);
 EXTERN S16 ueSendUeIpInfoRsp(U8 ueId,U8 bearedId, S8 * ipAddr);
-EXTERN Void populateIpAddrStrFromUeCb(U8 *temp_ip, UeCb *ueCb,U8 bearerId,
-        BearType *bearerType, NbuUeIpInfoRsp*);
+EXTERN Void populateIpInfo(UeCb *ueCb,U8 bearerId, NbuUeIpInfoRsp*);
 
-PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuPagingMsg(Pst *pst, UePagingMsg  *p_ueMsg);
 EXTERN S16 ueUiProcPagingMsg(UePagingMsg *p_ueMsg, Pst *pst);
 EXTERN S16 UeLiNbuUlRrcMsgDatRsp(Pst *pst, NbuUlRrcMsg *msg);
 EXTERN S16 ueSendUeRadCapInd(UeCb *ueCb);
 EXTERN S16 ueSendErabRelInd(NbuErabRelIndList *pErabRel, Pst *pst);
 PUBLIC S16 UeLiNbuErabRelInd(Pst *pst,NbuErabRelIndList *msg);
+
 PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst)
 {
    S16 ret = ROK;
-   U8 ipAddrStr[20] = {0};
-   BearType bearerType = 0;
    NbuUeIpInfoRsp  *ueIpInfoRsp = NULLP;
-   U16 destPort = 0;
-   //populateIpAddrStrFromUeCb(ipAddrStr,ueCb,bearerId,&bearerType, &destPort);
    ueIpInfoRsp = (NbuUeIpInfoRsp *)ueAlloc(sizeof(NbuUeIpInfoRsp));  
-   populateIpAddrStrFromUeCb(ipAddrStr,ueCb,bearerId,&bearerType, ueIpInfoRsp);
-   ueIpInfoRsp->ueId = ueCb->ueId;
-   ueIpInfoRsp->bearerId = bearerId;
-   ueIpInfoRsp->berType =  bearerType;
-/*   if (destPort)
-   {
-     ueIpInfoRsp->tft.remotePort = destPort;
-   }
-*/
-   strcpy(ueIpInfoRsp->IpAddr, (S8*)ipAddrStr);
+   populateIpInfo(ueCb, bearerId, ueIpInfoRsp);
 
    ret = UeLiNbuSendUeIpInfo(pst,ueIpInfoRsp);
    RETVALUE(ret);

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -111,7 +111,7 @@ EXTERN S16 ueSendUeRadCapInd(UeCb *ueCb);
 EXTERN S16 ueSendErabRelInd(NbuErabRelIndList *pErabRel, Pst *pst);
 PUBLIC S16 UeLiNbuErabRelInd(Pst *pst,NbuErabRelIndList *msg);
 
-PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst) 
+PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst)
 {
   S16 ret = ROK;
   NbuUeIpInfoRsp *ueIpInfoRsp = NULLP;

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -102,7 +102,7 @@ EXTERN S16 ueUiProcIpInfoReqMsg(UeCb * p_ueCb, U8 bearerId);
 EXTERN S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuUeIpInfoReq(Pst *pst,NbuUeIpInfoReq  *p_ueMsg);
 EXTERN S16 ueSendUeIpInfoRsp(U8 ueId,U8 bearedId, S8 * ipAddr);
-EXTERN Void populateIpInfo(UeCb *ueCb,U8 bearerId, NbuUeIpInfoRsp*);
+EXTERN Void populateIpInfo(UeCb *ueCb, U8 bearerId, NbuUeIpInfoRsp *);
 
 EXTERN S16 UeLiNbuPagingMsg(Pst *pst, UePagingMsg  *p_ueMsg);
 EXTERN S16 ueUiProcPagingMsg(UePagingMsg *p_ueMsg, Pst *pst);
@@ -111,15 +111,15 @@ EXTERN S16 ueSendUeRadCapInd(UeCb *ueCb);
 EXTERN S16 ueSendErabRelInd(NbuErabRelIndList *pErabRel, Pst *pst);
 PUBLIC S16 UeLiNbuErabRelInd(Pst *pst,NbuErabRelIndList *msg);
 
-PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst)
+PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst) 
 {
-   S16 ret = ROK;
-   NbuUeIpInfoRsp  *ueIpInfoRsp = NULLP;
-   ueIpInfoRsp = (NbuUeIpInfoRsp *)ueAlloc(sizeof(NbuUeIpInfoRsp));  
-   populateIpInfo(ueCb, bearerId, ueIpInfoRsp);
+  S16 ret = ROK;
+  NbuUeIpInfoRsp *ueIpInfoRsp = NULLP;
+  ueIpInfoRsp = (NbuUeIpInfoRsp *)ueAlloc(sizeof(NbuUeIpInfoRsp));
+  populateIpInfo(ueCb, bearerId, ueIpInfoRsp);
 
-   ret = UeLiNbuSendUeIpInfo(pst,ueIpInfoRsp);
-   RETVALUE(ret);
+  ret = UeLiNbuSendUeIpInfo(pst, ueIpInfoRsp);
+  RETVALUE(ret);
 }
 
 PUBLIC S16 UeLiNbuDlNasMsg

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -102,7 +102,8 @@ EXTERN S16 ueUiProcIpInfoReqMsg(UeCb * p_ueCb, U8 bearerId);
 EXTERN S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuUeIpInfoReq(Pst *pst,NbuUeIpInfoReq  *p_ueMsg);
 EXTERN S16 ueSendUeIpInfoRsp(U8 ueId,U8 bearedId, S8 * ipAddr);
-EXTERN Void populateIpAddrStrFromUeCb(U8 *temp_ip, UeCb *ueCb,U8 bearerId,BearType *bearerType);
+EXTERN Void populateIpAddrStrFromUeCb(U8 *temp_ip, UeCb *ueCb,U8 bearerId,
+        BearType *bearerType, NbuUeIpInfoRsp*);
 
 PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuPagingMsg(Pst *pst, UePagingMsg  *p_ueMsg);
@@ -117,11 +118,18 @@ PUBLIC S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb, U8 bearerId, Pst *pst)
    U8 ipAddrStr[20] = {0};
    BearType bearerType = 0;
    NbuUeIpInfoRsp  *ueIpInfoRsp = NULLP;
-   populateIpAddrStrFromUeCb(ipAddrStr,ueCb,bearerId,&bearerType);
+   U16 destPort = 0;
+   //populateIpAddrStrFromUeCb(ipAddrStr,ueCb,bearerId,&bearerType, &destPort);
    ueIpInfoRsp = (NbuUeIpInfoRsp *)ueAlloc(sizeof(NbuUeIpInfoRsp));  
+   populateIpAddrStrFromUeCb(ipAddrStr,ueCb,bearerId,&bearerType, ueIpInfoRsp);
    ueIpInfoRsp->ueId = ueCb->ueId;
    ueIpInfoRsp->bearerId = bearerId;
    ueIpInfoRsp->berType =  bearerType;
+/*   if (destPort)
+   {
+     ueIpInfoRsp->tft.remotePort = destPort;
+   }
+*/
    strcpy(ueIpInfoRsp->IpAddr, (S8*)ipAddrStr);
 
    ret = UeLiNbuSendUeIpInfo(pst,ueIpInfoRsp);


### PR DESCRIPTION
## Title
Added UL TFT support in S1 SIM

## Summary
Added code to store the UL TFT packet filter/s in the order of precedence and send the UL IP packet on the dedicated bearer if the packet filter matches. If not the packet is sent on default bearer.

## Test plan
- Executed test_attach_detach_rar_tcp_data.py test case from PR #1442
