### PR TITLE
S1sim pcscf address support

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -27,7 +27,7 @@ extern "C" {
 
 #define UE_IMSI_LENGTH 15
 #define CM_EMM_MAX_MOBILE_ID_DIGS 15
-#define MAX_APN_LEN 6
+#define MAX_APN_LEN 50
 #define OP_KEY_LEN 16
 #define SHARED_KEY_LEN 16
 #define EVTUEMSGREQ 0

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -325,6 +325,7 @@ typedef struct _ueUetPdnConReq
    U32             pdnType;
    UeEmmNasPdnApn  nasPdnApn;
    U8              reqType;
+   UeEsmProtCfgOpt protCfgOpt;
 }UeUetPdnConReq;
 
 typedef struct _uePdnRejectInfo

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -319,14 +319,13 @@ PDN APN */
    Bool eti; /*Esm Information Transfer Flag*/
 }UeUetAttachReq;
 
-typedef struct _ueUetPdnConReq
-{
-   U8              ueId;
-   U32             pdnType;
-   UeEmmNasPdnApn  nasPdnApn;
-   U8              reqType;
-   UeEsmProtCfgOpt protCfgOpt;
-}UeUetPdnConReq;
+typedef struct _ueUetPdnConReq {
+  U8 ueId;
+  U32 pdnType;
+  UeEmmNasPdnApn nasPdnApn;
+  U8 reqType;
+  UeEsmProtCfgOpt protCfgOpt;
+} UeUetPdnConReq;
 
 typedef struct _uePdnRejectInfo
 {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -594,47 +594,6 @@ PRIVATE Void insert_ue_entry(U8 ueid, UeIdCb *ueIdCb)
    FW_LOG_EXITFNVOID(fwCb);
 }
 
- /*
- *
- *   Fun:   fill_pco
- *
- *   Desc:  This function is used to populate PCO structure
- *
- *   Ret:   None
- *
- *   Notes: None
- *
- *   File:  fw_api_int.c
- *
- */
-PRIVATE Void fill_pco(prot_CfgOpts *dest_pco, prot_CfgOpts src_pco)
-{
-  dest_pco->pres = TRUE;
-  dest_pco->len = src_pco.len;
-  dest_pco->cfgProt = src_pco.cfgProt;
-  dest_pco->ext = src_pco.ext;
-  dest_pco->numProtId = src_pco.numProtId;
-  dest_pco->numContId = src_pco.numContId;
-
-  U8 count;
-  for (count=0;count<src_pco.numProtId;count ++) {
-    dest_pco->p[count].pid = src_pco.p[count].pid;
-    dest_pco->p[count].len = src_pco.p[count].len;
-    cmMemcpy(dest_pco->p[count].val,
-      src_pco.p[count].val,
-      src_pco.p[count].len);
-  }
-
-  for (count=0;count<src_pco.numContId;count ++) {
-    dest_pco->c[count].cid = src_pco.c[count].cid;
-    dest_pco->c[count].len = src_pco.c[count].len;
-    cmMemcpy(dest_pco->c[count].val,
-      src_pco.c[count].val,
-      src_pco.c[count].len);
-  }
-  RETVOID;
-}
-
 /*
  *
  *   Fun:   handleEndToEndAttachReq
@@ -730,8 +689,28 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
    }
    if (data->protCfgOpts_pr.pres == TRUE)
    {
-      fill_pco(&ueAttachReq->protCfgOpt, data->protCfgOpts_pr);
-
+      ueAttachReq->protCfgOpt.pres = TRUE;
+      ueAttachReq->protCfgOpt.len = data->protCfgOpts_pr.len;
+      ueAttachReq->protCfgOpt.cfgProt = data->protCfgOpts_pr.cfgProt;
+      ueAttachReq->protCfgOpt.ext = data->protCfgOpts_pr.ext;
+      ueAttachReq->protCfgOpt.numProtId = data->protCfgOpts_pr.numProtId;
+      ueAttachReq->protCfgOpt.numContId = data->protCfgOpts_pr.numContId;
+      for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
+      {
+         ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
+         ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
+         cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
+               data->protCfgOpts_pr.p[count].val,
+               data->protCfgOpts_pr.p[count].len);
+      }
+      for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
+      {
+         ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
+         ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
+         cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
+               data->protCfgOpts_pr.c[count].val,
+               data->protCfgOpts_pr.c[count].len);
+      }
    }
    if(data->drxParm_pr.pres)
    	{
@@ -2463,7 +2442,7 @@ PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
    }
    // PCO
    if (data->protCfgOpts_pr.pres) {
-     fill_pco(&uePdnConReq->protCfgOpt, data->protCfgOpts_pr);
+     cmMemcpy(&uePdnConReq->protCfgOpt, &data->protCfgOpts_pr, sizeof(data->protCfgOpts_pr));
    }
    fwSendToUeApp(uetMsg);
    FW_LOG_DEBUG(fwCb, "\n-------------------------------\n\

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -689,28 +689,28 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
    }
    if (data->protCfgOpts_pr.pres == TRUE)
    {
-      ueAttachReq->protCfgOpt.pres = TRUE;
-      ueAttachReq->protCfgOpt.len = data->protCfgOpts_pr.len;
-      ueAttachReq->protCfgOpt.cfgProt = data->protCfgOpts_pr.cfgProt;
-      ueAttachReq->protCfgOpt.ext = data->protCfgOpts_pr.ext;
-      ueAttachReq->protCfgOpt.numProtId = data->protCfgOpts_pr.numProtId;
-      ueAttachReq->protCfgOpt.numContId = data->protCfgOpts_pr.numContId;
-      for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
-      {
-         ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
-         ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-         cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
-               data->protCfgOpts_pr.p[count].val,
-               data->protCfgOpts_pr.p[count].len);
-      }
-      for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
-      {
-         ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
-         ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-         cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
-               data->protCfgOpts_pr.c[count].val,
-               data->protCfgOpts_pr.c[count].len);
-      }
+   	  ueAttachReq->protCfgOpt.pres = TRUE;
+	  ueAttachReq->protCfgOpt.len = data->protCfgOpts_pr.len;
+	  ueAttachReq->protCfgOpt.cfgProt = data->protCfgOpts_pr.cfgProt;
+	  ueAttachReq->protCfgOpt.ext = data->protCfgOpts_pr.ext;
+	  ueAttachReq->protCfgOpt.numProtId = data->protCfgOpts_pr.numProtId;
+	  ueAttachReq->protCfgOpt.numContId = data->protCfgOpts_pr.numContId;
+	  for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
+	  {
+	  	ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
+	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
+			   data->protCfgOpts_pr.p[count].val, 
+			   data->protCfgOpts_pr.p[count].len);
+	  }
+	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
+	  {
+	  	ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
+	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
+			   data->protCfgOpts_pr.c[count].val, 
+			   data->protCfgOpts_pr.c[count].len);
+	  }
    }
    if(data->drxParm_pr.pres)
    	{
@@ -836,18 +836,18 @@ PUBLIC S16 handleAttachReq(ueAttachRequest_t *data)
 	  for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
-			   data->protCfgOpts_pr.p[count].val,
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
+			   data->protCfgOpts_pr.p[count].val, 
 			   data->protCfgOpts_pr.p[count].len);
 	  }
 	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
-			   data->protCfgOpts_pr.c[count].val,
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
+			   data->protCfgOpts_pr.c[count].val, 
 			   data->protCfgOpts_pr.c[count].len);
 	  }
-   }
+   }  
    if(data->drxParm_pr.pres)
    	{
    	  ueAttachReq->drxParm.pres = TRUE;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -699,16 +699,16 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
 	  {
 	  	ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
 	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
-			   data->protCfgOpts_pr.p[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
+			   data->protCfgOpts_pr.p[count].val,
 			   data->protCfgOpts_pr.p[count].len);
 	  }
 	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
 	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
-			   data->protCfgOpts_pr.c[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
+			   data->protCfgOpts_pr.c[count].val,
 			   data->protCfgOpts_pr.c[count].len);
 	  }
    }

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -2398,61 +2398,55 @@ Void initTestFrameWork(TestCnrlrCallBack func)
  *   File:  fw_api_int.c
  *
  */
-PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
+PRIVATE Void handlPdnConReq(uepdnConReq_t *data)
 {
-   FwCb *fwCb = NULLP;
-   S16 ret;
-   UetMessage *uetMsg = NULLP;
-   UeUetPdnConReq *uePdnConReq = NULLP;
-   UeIdCb *ueIdCb = NULLP;
+  FwCb *fwCb = NULLP;
+  S16 ret;
+  UetMessage *uetMsg = NULLP;
+  UeUetPdnConReq *uePdnConReq = NULLP;
+  UeIdCb *ueIdCb = NULLP;
 
-   FW_GET_CB(fwCb);
-   FW_LOG_ENTERFN(fwCb);
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
 
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
-            (Data **)&uetMsg, (Size) sizeof(UetMessage)) == ROK)
-   {
-      cmMemset((U8 *)(uetMsg), 0,sizeof(UetMessage));
-   }
-   else
-   {
-      RETVOID;
-   }
-   if (SGetSBuf(fwCb->init.region, fwCb->init.pool,
-            (Data **)&ueIdCb, (Size) sizeof(UeIdCb)) == ROK)
-   {
-      cmMemset((U8 *)(ueIdCb), 0,sizeof(UeIdCb));
-   }
-   else
-   {
-      RETVOID;
-   }
+  if (SGetSBuf(fwCb->init.region, fwCb->init.pool, (Data **)&uetMsg,
+               (Size)sizeof(UetMessage)) == ROK) {
+    cmMemset((U8 *)(uetMsg), 0, sizeof(UetMessage));
+  } else {
+    RETVOID;
+  }
+  if (SGetSBuf(fwCb->init.region, fwCb->init.pool, (Data **)&ueIdCb,
+               (Size)sizeof(UeIdCb)) == ROK) {
+    cmMemset((U8 *)(ueIdCb), 0, sizeof(UeIdCb));
+  } else {
+    RETVOID;
+  }
 
-   insertUeCb(data->ue_Id, 0, 0, ueIdCb);
-   uetMsg->msgType = UE_PDN_CON_REQ_TYPE;
-   uePdnConReq = &uetMsg->msg.ueUetPdnConReq;
-   uePdnConReq->ueId    = data->ue_Id;
-   if(data->pdnType_pr.pres == TRUE)
-      uePdnConReq->pdnType = data->pdnType_pr.pdn_type;
-   uePdnConReq->reqType = data->reqType;
-   if(data->pdnAPN_pr.pres == TRUE)
-   {
-      uePdnConReq->nasPdnApn.len = data->pdnAPN_pr.len;
-      cmMemcpy(uePdnConReq->nasPdnApn.apn, data->pdnAPN_pr.pdn_apn,data->pdnAPN_pr.len);
-   }
-   // PCO
-   if (data->protCfgOpts_pr.pres) {
-     cmMemcpy(&uePdnConReq->protCfgOpt, &data->protCfgOpts_pr, sizeof(data->protCfgOpts_pr));
-   }
-   fwSendToUeApp(uetMsg);
-   FW_LOG_DEBUG(fwCb, "\n-------------------------------\n\
+  insertUeCb(data->ue_Id, 0, 0, ueIdCb);
+  uetMsg->msgType = UE_PDN_CON_REQ_TYPE;
+  uePdnConReq = &uetMsg->msg.ueUetPdnConReq;
+  uePdnConReq->ueId = data->ue_Id;
+  if (data->pdnType_pr.pres == TRUE)
+    uePdnConReq->pdnType = data->pdnType_pr.pdn_type;
+  uePdnConReq->reqType = data->reqType;
+  if (data->pdnAPN_pr.pres == TRUE) {
+    uePdnConReq->nasPdnApn.len = data->pdnAPN_pr.len;
+    cmMemcpy(uePdnConReq->nasPdnApn.apn, data->pdnAPN_pr.pdn_apn,
+             data->pdnAPN_pr.len);
+  }
+  // PCO
+  if (data->protCfgOpts_pr.pres) {
+    cmMemcpy(&uePdnConReq->protCfgOpt, &data->protCfgOpts_pr,
+             sizeof(data->protCfgOpts_pr));
+  }
+  fwSendToUeApp(uetMsg);
+  FW_LOG_DEBUG(fwCb, "\n-------------------------------\n\
             Starting T3482\n-------------------------------\n");
-   ret = fwStartTmr(fwCb, ueIdCb, fwHndlPdnTmrExp, 800);
-   if (ROK != ret)
-   {
-      FW_LOG_ERROR(fwCb, "Failed to start T3482 timer");
-   }
-   RETVOID;
+  ret = fwStartTmr(fwCb, ueIdCb, fwHndlPdnTmrExp, 800);
+  if (ROK != ret) {
+    FW_LOG_ERROR(fwCb, "Failed to start T3482 timer");
+  }
+  RETVOID;
 }
 
 /*

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -836,18 +836,18 @@ PUBLIC S16 handleAttachReq(ueAttachRequest_t *data)
 	  for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val, 
-			   data->protCfgOpts_pr.p[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
+			   data->protCfgOpts_pr.p[count].val,
 			   data->protCfgOpts_pr.p[count].len);
 	  }
 	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
 	  {
 	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val, 
-			   data->protCfgOpts_pr.c[count].val, 
+		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
+			   data->protCfgOpts_pr.c[count].val,
 			   data->protCfgOpts_pr.c[count].len);
 	  }
-   }  
+   }
    if(data->drxParm_pr.pres)
    	{
    	  ueAttachReq->drxParm.pres = TRUE;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -594,6 +594,47 @@ PRIVATE Void insert_ue_entry(U8 ueid, UeIdCb *ueIdCb)
    FW_LOG_EXITFNVOID(fwCb);
 }
 
+ /*
+ *
+ *   Fun:   fill_pco
+ *
+ *   Desc:  This function is used to populate PCO structure
+ *
+ *   Ret:   None
+ *
+ *   Notes: None
+ *
+ *   File:  fw_api_int.c
+ *
+ */
+PRIVATE Void fill_pco(prot_CfgOpts *dest_pco, prot_CfgOpts src_pco)
+{
+  dest_pco->pres = TRUE;
+  dest_pco->len = src_pco.len;
+  dest_pco->cfgProt = src_pco.cfgProt;
+  dest_pco->ext = src_pco.ext;
+  dest_pco->numProtId = src_pco.numProtId;
+  dest_pco->numContId = src_pco.numContId;
+
+  U8 count;
+  for (count=0;count<src_pco.numProtId;count ++) {
+    dest_pco->p[count].pid = src_pco.p[count].pid;
+    dest_pco->p[count].len = src_pco.p[count].len;
+    cmMemcpy(dest_pco->p[count].val,
+      src_pco.p[count].val,
+      src_pco.p[count].len);
+  }
+
+  for (count=0;count<src_pco.numContId;count ++) {
+    dest_pco->c[count].cid = src_pco.c[count].cid;
+    dest_pco->c[count].len = src_pco.c[count].len;
+    cmMemcpy(dest_pco->c[count].val,
+      src_pco.c[count].val,
+      src_pco.c[count].len);
+  }
+  RETVOID;
+}
+
 /*
  *
  *   Fun:   handleEndToEndAttachReq
@@ -689,28 +730,8 @@ PUBLIC S16 handleEndToEndAttachReq(ueAttachRequest_t *data)
    }
    if (data->protCfgOpts_pr.pres == TRUE)
    {
-   	  ueAttachReq->protCfgOpt.pres = TRUE;
-	  ueAttachReq->protCfgOpt.len = data->protCfgOpts_pr.len;
-	  ueAttachReq->protCfgOpt.cfgProt = data->protCfgOpts_pr.cfgProt;
-	  ueAttachReq->protCfgOpt.ext = data->protCfgOpts_pr.ext;
-	  ueAttachReq->protCfgOpt.numProtId = data->protCfgOpts_pr.numProtId;
-	  ueAttachReq->protCfgOpt.numContId = data->protCfgOpts_pr.numContId;
-	  for (count=0;count<data->protCfgOpts_pr.numProtId;count ++)
-	  {
-	  	ueAttachReq->protCfgOpt.p[count].pid = data->protCfgOpts_pr.p[count].pid;
-	  	ueAttachReq->protCfgOpt.p[count].len = data->protCfgOpts_pr.p[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.p[count].val,
-			   data->protCfgOpts_pr.p[count].val,
-			   data->protCfgOpts_pr.p[count].len);
-	  }
-	  for (count=0;count<data->protCfgOpts_pr.numContId;count ++)
-	  {
-	  	ueAttachReq->protCfgOpt.c[count].cid = data->protCfgOpts_pr.c[count].cid;
-	  	ueAttachReq->protCfgOpt.c[count].len = data->protCfgOpts_pr.c[count].len;
-		cmMemcpy(ueAttachReq->protCfgOpt.c[count].val,
-			   data->protCfgOpts_pr.c[count].val,
-			   data->protCfgOpts_pr.c[count].len);
-	  }
+      fill_pco(&ueAttachReq->protCfgOpt, data->protCfgOpts_pr);
+
    }
    if(data->drxParm_pr.pres)
    	{
@@ -2439,6 +2460,10 @@ PRIVATE Void handlPdnConReq(uepdnConReq_t* data)
    {
       uePdnConReq->nasPdnApn.len = data->pdnAPN_pr.len;
       cmMemcpy(uePdnConReq->nasPdnApn.apn, data->pdnAPN_pr.pdn_apn,data->pdnAPN_pr.len);
+   }
+   // PCO
+   if (data->protCfgOpts_pr.pres) {
+     fill_pco(&uePdnConReq->protCfgOpt, data->protCfgOpts_pr);
    }
    fwSendToUeApp(uetMsg);
    FW_LOG_DEBUG(fwCb, "\n-------------------------------\n\

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -931,6 +931,7 @@ typedef struct uepdnConReq
    U8       reqType;
    pdn_Type pdnType_pr;
    pdn_APN  pdnAPN_pr;
+   prot_CfgOpts protCfgOpts_pr;
 }uepdnConReq_t;
 
 typedef struct uepdnDisconnectReq {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -925,14 +925,13 @@ typedef struct ueCntxtRelReq
    RelCause cause;
 }ueCntxtRelReq_t;
 
-typedef struct uepdnConReq
-{
-   U8       ue_Id;
-   U8       reqType;
-   pdn_Type pdnType_pr;
-   pdn_APN  pdnAPN_pr;
-   prot_CfgOpts protCfgOpts_pr;
-}uepdnConReq_t;
+typedef struct uepdnConReq {
+  U8 ue_Id;
+  U8 reqType;
+  pdn_Type pdnType_pr;
+  pdn_APN pdnAPN_pr;
+  prot_CfgOpts protCfgOpts_pr;
+} uepdnConReq_t;
 
 typedef struct uepdnDisconnectReq {
   U8 ue_Id;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1032,22 +1032,22 @@ PRIVATE S16 ueAppUtlBldPdnConReq
       msg->u.conReq.protCfgOpt.ext = protCfgOpt->ext;
       msg->u.conReq.protCfgOpt.numProtId = protCfgOpt->numProtId;
       msg->u.conReq.protCfgOpt.numContId = protCfgOpt->numContId;
-
-      for (count=0;count<protCfgOpt->numProtId;count ++)
-      {
-         msg->u.conReq.protCfgOpt.p[count].pid = protCfgOpt->p[count].pid;
-         msg->u.conReq.protCfgOpt.p[count].len = protCfgOpt->p[count].len;
-         cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val,
-               protCfgOpt->p[count].val,
-               protCfgOpt->p[count].len);
-      }
-      for (count=0;count<protCfgOpt->numContId;count ++)
-      {
-         msg->u.conReq.protCfgOpt.c[count].cid = protCfgOpt->c[count].cid;
-         msg->u.conReq.protCfgOpt.c[count].len = protCfgOpt->c[count].len;
-         cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val,
-               protCfgOpt->c[count].val,
-               protCfgOpt->c[count].len);
+  
+     for (count=0;count<protCfgOpt->numProtId;count ++)
+     {
+  	msg->u.conReq.protCfgOpt.p[count].pid = protCfgOpt->p[count].pid;
+  	msg->u.conReq.protCfgOpt.p[count].len = protCfgOpt->p[count].len;
+	cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val, 
+		   protCfgOpt->p[count].val, 
+		   protCfgOpt->p[count].len);
+     }
+     for (count=0;count<protCfgOpt->numContId;count ++)
+     {
+  	msg->u.conReq.protCfgOpt.c[count].cid = protCfgOpt->c[count].cid;
+  	msg->u.conReq.protCfgOpt.c[count].len = protCfgOpt->c[count].len;
+	cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val, 
+		   protCfgOpt->c[count].val, 
+		   protCfgOpt->c[count].len);
       }
    }
 

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1032,21 +1032,21 @@ PRIVATE S16 ueAppUtlBldPdnConReq
       msg->u.conReq.protCfgOpt.ext = protCfgOpt->ext;
       msg->u.conReq.protCfgOpt.numProtId = protCfgOpt->numProtId;
       msg->u.conReq.protCfgOpt.numContId = protCfgOpt->numContId;
-  
+
      for (count=0;count<protCfgOpt->numProtId;count ++)
      {
   	msg->u.conReq.protCfgOpt.p[count].pid = protCfgOpt->p[count].pid;
   	msg->u.conReq.protCfgOpt.p[count].len = protCfgOpt->p[count].len;
-	cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val, 
-		   protCfgOpt->p[count].val, 
+	cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val,
+		   protCfgOpt->p[count].val,
 		   protCfgOpt->p[count].len);
      }
      for (count=0;count<protCfgOpt->numContId;count ++)
      {
   	msg->u.conReq.protCfgOpt.c[count].cid = protCfgOpt->c[count].cid;
   	msg->u.conReq.protCfgOpt.c[count].len = protCfgOpt->c[count].len;
-	cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val, 
-		   protCfgOpt->c[count].val, 
+	cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val,
+		   protCfgOpt->c[count].val,
 		   protCfgOpt->c[count].len);
       }
    }

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -879,6 +879,44 @@ PRIVATE S16 encode_apn
    RETVALUE(RFAILED);
 }
 
+ /*
+ *
+ *       Fun: ueAppFillPco
+ *
+ *       Desc: This function populates PCO structure.
+ *
+ *       Notes: none
+ *
+ *       File:  ue_app.c
+ *
+ */
+PRIVATE Void ueAppFillPco(CmEsmProtCfgOpt *dest_pco, UeEsmProtCfgOpt src_pco)
+{
+  dest_pco->protCfgOpt.pres = TRUE;
+  dest_pco->protCfgOpt.cfgProt = src_pco.protCfgOpt.cfgProt;
+  dest_pco->protCfgOpt.ext = src_pco.protCfgOpt.ext;
+  dest_pco->protCfgOpt.numProtId = src_pco.protCfgOpt.numProtId;
+  dest_pco->protCfgOpt.numContId = src_pco.protCfgOpt.numContId;
+
+  U8 count = 0;
+  for (count=0;count<src_pco.protCfgOpt.numProtId;count ++) {
+    dest_pco->protCfgOpt.p[count].pid = src_pco.protCfgOpt.p[count].pid;
+    dest_pco->protCfgOpt.p[count].len = src_pco.protCfgOpt.p[count].len;
+    cmMemcpy(dest_pco->protCfgOpt.p[count].val,
+      src_pco.protCfgOpt.p[count].val,
+      src_pco.protCfgOpt.p[count].len);
+  }
+  for (count=0;count<src_pco.protCfgOpt.numContId;count ++) {
+    dest_pco->protCfgOpt.c[count].cid = src_pco.protCfgOpt.c[count].cid;
+    dest_pco->protCfgOpt.c[count].len = src_pco.protCfgOpt.c[count].len;
+    cmMemcpy(dest_pco->protCfgOpt.c[count].val,
+      src_pco.protCfgOpt.c[count].val,
+      src_pco.protCfgOpt.c[count].len);
+  }
+  RETVOID;
+}
+
+
 PRIVATE S16 ueAppUtlBldStandAlonePdnConReq
 (
  CmNasEvnt **esmEvnt,
@@ -932,6 +970,12 @@ PRIVATE S16 ueAppUtlBldStandAlonePdnConReq
      encode_apn(&msg->u.conReq.apn,&ueUetPdnConReq->nasPdnApn);
     } else {
      msg->u.conReq.apn.pres      = FALSE;
+   }
+   /* protocol configuration options */
+   ueAppFillPco(msg->u.conReq.protCfgOpt, ueUetPdnConReq->protCfgOpt);
+   if(ueUetPdnConReq->protCfgOpt.pres == TRUE)
+   {
+
    }
    RETVALUE(ROK);
 }
@@ -1022,28 +1066,7 @@ PRIVATE S16 ueAppUtlBldPdnConReq
    /* protocol configuration options */
    if(protCfgOpt->pres == TRUE)
    {
-      msg->u.conReq.protCfgOpt.pres = TRUE;
-      msg->u.conReq.protCfgOpt.cfgProt = protCfgOpt->cfgProt;
-      msg->u.conReq.protCfgOpt.ext = protCfgOpt->ext;
-      msg->u.conReq.protCfgOpt.numProtId = protCfgOpt->numProtId;
-      msg->u.conReq.protCfgOpt.numContId = protCfgOpt->numContId;
-
-     for (count=0;count<protCfgOpt->numProtId;count ++)
-     {
-  	msg->u.conReq.protCfgOpt.p[count].pid = protCfgOpt->p[count].pid;
-  	msg->u.conReq.protCfgOpt.p[count].len = protCfgOpt->p[count].len;
-	cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val,
-		   protCfgOpt->p[count].val,
-		   protCfgOpt->p[count].len);
-     }
-     for (count=0;count<protCfgOpt->numContId;count ++)
-     {
-  	msg->u.conReq.protCfgOpt.c[count].cid = protCfgOpt->c[count].cid;
-  	msg->u.conReq.protCfgOpt.c[count].len = protCfgOpt->c[count].len;
-	cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val,
-		   protCfgOpt->c[count].val,
-		   protCfgOpt->c[count].len);
-      }
+     ueAppFillPco(msg->u.conReq.protCfgOpt, *protCfgOpt);
    }
 
    RETVALUE(ROK);

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -879,66 +879,60 @@ PRIVATE S16 encode_apn
    RETVALUE(RFAILED);
 }
 
-PRIVATE S16 ueAppUtlBldStandAlonePdnConReq
-(
- CmNasEvnt **esmEvnt,
- UeUetPdnConReq *ueUetPdnConReq
-)
+PRIVATE S16 ueAppUtlBldStandAlonePdnConReq(CmNasEvnt **esmEvnt,
+                                           UeUetPdnConReq *ueUetPdnConReq)
 {
-   CmEsmMsg    *msg = NULLP;
-   printf("Building PDN Connection Request\n");
+  CmEsmMsg *msg = NULLP;
+  printf("Building PDN Connection Request\n");
 
-   if(esmEvnt == NULLP)
-   {
-      RETVALUE(RFAILED);
-   }
+  if (esmEvnt == NULLP) {
+    RETVALUE(RFAILED);
+  }
 
-   /* Allocate memory for mme evnt */
-   CM_ALLOC_NASEVNT (esmEvnt, CM_ESM_PD);
-   if (*esmEvnt == NULLP)
-   {
-      RETVALUE(RFAILED);
-   }
+  /* Allocate memory for mme evnt */
+  CM_ALLOC_NASEVNT(esmEvnt, CM_ESM_PD);
+  if (*esmEvnt == NULLP) {
+    RETVALUE(RFAILED);
+  }
 
-   /*Allocate memory for ESM message*/
-   if (cmGetMem(&(*esmEvnt)->memCp, sizeof(CmEsmMsg), (Ptr *)&msg) != ROK)
-   {
-      CM_FREE_NASEVNT(esmEvnt);
-      RETVALUE(RFAILED);
-   }
+  /*Allocate memory for ESM message*/
+  if (cmGetMem(&(*esmEvnt)->memCp, sizeof(CmEsmMsg), (Ptr *)&msg) != ROK) {
+    CM_FREE_NASEVNT(esmEvnt);
+    RETVALUE(RFAILED);
+  }
 
-   msg->protDisc = CM_ESM_PD;
-   (*esmEvnt)->m.esmEvnt = msg;
+  msg->protDisc = CM_ESM_PD;
+  (*esmEvnt)->m.esmEvnt = msg;
 
-   (*esmEvnt)->secHT = CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC;
-   /* Fill ESM PDN connectivity request message */
+  (*esmEvnt)->secHT = CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC;
+  /* Fill ESM PDN connectivity request message */
 
-   /*Fill mandatory IE's*/
-   /* EPS barer ID IE*/
-   msg->bearerId = 0;
+  /*Fill mandatory IE's*/
+  /* EPS barer ID IE*/
+  msg->bearerId = 0;
 
-   /* PDN connectivity request message idenmtity*/
-   msg->msgType = CM_ESM_MSG_PDN_CONN_REQ;
+  /* PDN connectivity request message idenmtity*/
+  msg->msgType = CM_ESM_MSG_PDN_CONN_REQ;
 
-   /* Request type IE*/
-   msg->u.conReq.reqType.pres = TRUE;
-   msg->u.conReq.reqType.val = CM_ESM_REQTYPE_INIT;
-   /* PDN type IE*/
-   msg->u.conReq.pdnType.pres = TRUE;
-   msg->u.conReq.pdnType.val = ueUetPdnConReq->pdnType;
+  /* Request type IE*/
+  msg->u.conReq.reqType.pres = TRUE;
+  msg->u.conReq.reqType.val = CM_ESM_REQTYPE_INIT;
+  /* PDN type IE*/
+  msg->u.conReq.pdnType.pres = TRUE;
+  msg->u.conReq.pdnType.val = ueUetPdnConReq->pdnType;
 
-   if( ueUetPdnConReq->nasPdnApn.len != 0) {
-     msg->u.conReq.apn.pres      = TRUE;
-     encode_apn(&msg->u.conReq.apn,&ueUetPdnConReq->nasPdnApn);
-    } else {
-     msg->u.conReq.apn.pres      = FALSE;
-   }
-   /* protocol configuration options */
-   if(ueUetPdnConReq->protCfgOpt.pres == TRUE) {
-     cmMemcpy(&msg->u.conReq.protCfgOpt, &ueUetPdnConReq->protCfgOpt,
-           sizeof(ueUetPdnConReq->protCfgOpt));
-   }
-   RETVALUE(ROK);
+  if (ueUetPdnConReq->nasPdnApn.len != 0) {
+    msg->u.conReq.apn.pres = TRUE;
+    encode_apn(&msg->u.conReq.apn, &ueUetPdnConReq->nasPdnApn);
+  } else {
+    msg->u.conReq.apn.pres = FALSE;
+  }
+  /* protocol configuration options */
+  if (ueUetPdnConReq->protCfgOpt.pres == TRUE) {
+    cmMemcpy(&msg->u.conReq.protCfgOpt, &ueUetPdnConReq->protCfgOpt,
+             sizeof(ueUetPdnConReq->protCfgOpt));
+  }
+  RETVALUE(ROK);
 }
 
 /*

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -879,44 +879,6 @@ PRIVATE S16 encode_apn
    RETVALUE(RFAILED);
 }
 
- /*
- *
- *       Fun: ueAppFillPco
- *
- *       Desc: This function populates PCO structure.
- *
- *       Notes: none
- *
- *       File:  ue_app.c
- *
- */
-PRIVATE Void ueAppFillPco(CmEsmProtCfgOpt *dest_pco, UeEsmProtCfgOpt src_pco)
-{
-  dest_pco->protCfgOpt.pres = TRUE;
-  dest_pco->protCfgOpt.cfgProt = src_pco.protCfgOpt.cfgProt;
-  dest_pco->protCfgOpt.ext = src_pco.protCfgOpt.ext;
-  dest_pco->protCfgOpt.numProtId = src_pco.protCfgOpt.numProtId;
-  dest_pco->protCfgOpt.numContId = src_pco.protCfgOpt.numContId;
-
-  U8 count = 0;
-  for (count=0;count<src_pco.protCfgOpt.numProtId;count ++) {
-    dest_pco->protCfgOpt.p[count].pid = src_pco.protCfgOpt.p[count].pid;
-    dest_pco->protCfgOpt.p[count].len = src_pco.protCfgOpt.p[count].len;
-    cmMemcpy(dest_pco->protCfgOpt.p[count].val,
-      src_pco.protCfgOpt.p[count].val,
-      src_pco.protCfgOpt.p[count].len);
-  }
-  for (count=0;count<src_pco.protCfgOpt.numContId;count ++) {
-    dest_pco->protCfgOpt.c[count].cid = src_pco.protCfgOpt.c[count].cid;
-    dest_pco->protCfgOpt.c[count].len = src_pco.protCfgOpt.c[count].len;
-    cmMemcpy(dest_pco->protCfgOpt.c[count].val,
-      src_pco.protCfgOpt.c[count].val,
-      src_pco.protCfgOpt.c[count].len);
-  }
-  RETVOID;
-}
-
-
 PRIVATE S16 ueAppUtlBldStandAlonePdnConReq
 (
  CmNasEvnt **esmEvnt,
@@ -972,10 +934,9 @@ PRIVATE S16 ueAppUtlBldStandAlonePdnConReq
      msg->u.conReq.apn.pres      = FALSE;
    }
    /* protocol configuration options */
-   ueAppFillPco(msg->u.conReq.protCfgOpt, ueUetPdnConReq->protCfgOpt);
-   if(ueUetPdnConReq->protCfgOpt.pres == TRUE)
-   {
-
+   if(ueUetPdnConReq->protCfgOpt.pres == TRUE) {
+     cmMemcpy(&msg->u.conReq.protCfgOpt, &ueUetPdnConReq->protCfgOpt,
+           sizeof(ueUetPdnConReq->protCfgOpt));
    }
    RETVALUE(ROK);
 }
@@ -1066,7 +1027,28 @@ PRIVATE S16 ueAppUtlBldPdnConReq
    /* protocol configuration options */
    if(protCfgOpt->pres == TRUE)
    {
-     ueAppFillPco(msg->u.conReq.protCfgOpt, *protCfgOpt);
+      msg->u.conReq.protCfgOpt.pres = TRUE;
+      msg->u.conReq.protCfgOpt.cfgProt = protCfgOpt->cfgProt;
+      msg->u.conReq.protCfgOpt.ext = protCfgOpt->ext;
+      msg->u.conReq.protCfgOpt.numProtId = protCfgOpt->numProtId;
+      msg->u.conReq.protCfgOpt.numContId = protCfgOpt->numContId;
+
+      for (count=0;count<protCfgOpt->numProtId;count ++)
+      {
+         msg->u.conReq.protCfgOpt.p[count].pid = protCfgOpt->p[count].pid;
+         msg->u.conReq.protCfgOpt.p[count].len = protCfgOpt->p[count].len;
+         cmMemcpy(msg->u.conReq.protCfgOpt.p[count].val,
+               protCfgOpt->p[count].val,
+               protCfgOpt->p[count].len);
+      }
+      for (count=0;count<protCfgOpt->numContId;count ++)
+      {
+         msg->u.conReq.protCfgOpt.c[count].cid = protCfgOpt->c[count].cid;
+         msg->u.conReq.protCfgOpt.c[count].len = protCfgOpt->c[count].len;
+         cmMemcpy(msg->u.conReq.protCfgOpt.c[count].val,
+               protCfgOpt->c[count].val,
+               protCfgOpt->c[count].len);
+      }
    }
 
    RETVALUE(ROK);


### PR DESCRIPTION
## Title
P-CSCF support in S1 SIM

## Summary
Added P-CSCF IPv4 and IPv6 address support

Test Plan:
1.	Verified S1 SIM sanity
2.	Executed 2 new TCs: test_attach_detach_with_pcscf_address.py and 
        test_attach_detach_secondary_pdn_with_pcscf_address.py PR - #1577
       

