### PR TITLE
[Bug fix] Fixed printing of ue id multiple times

### DIFF
--- a/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
+++ b/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
@@ -1360,6 +1360,7 @@ PUBLIC S16 handleTauRejectInd
    {
       fwStopTmr(fwCb, ueIdCb);
       delete_ue_entries(ueIdCb->ue_id);
+      FW_FREE_MEM(fwCb, ueIdCb, sizeof(UeIdCb));
       ret = sendUeTauRejectIndToTstCntrl(uetTauRejInd);
    }
    else
@@ -1531,12 +1532,12 @@ PRIVATE S16 handlePdnConRspInd
       tmpNode = tmpNode->next;
    }
 
-   FW_LOG_DEBUG(fwCb, "\nStoping timer T3482\n");
-
-   if (flag == 1)
-   {
-      fwStopTmr(fwCb, ueIdCb);
-      ret = sendUePdnConRspIndToTstCntlr(uetPdnConRspInd);
+   if (flag == 1) {
+     FW_LOG_DEBUG(fwCb, "\nStoping timer T3482\n");
+     fwStopTmr(fwCb, ueIdCb);
+     delete_ue_entries(ueIdCb->ue_id);
+     FW_FREE_MEM(fwCb, ueIdCb, sizeof(UeIdCb));
+     ret = sendUePdnConRspIndToTstCntlr(uetPdnConRspInd);
    }
    else
    {
@@ -1651,10 +1652,11 @@ PRIVATE S16 handleAndSendDeActvBerReqInd
        tmpNode = tmpNode->next;
    }
 
-   if (flag == 1)
-   {
-       FW_LOG_DEBUG(fwCb, "\nStoping timer T3492\n");
-       fwStopTmr(fwCb, ueIdCb);
+   if (flag == 1) {
+     FW_LOG_DEBUG(fwCb, "\nStoping timer T3492\n");
+     fwStopTmr(fwCb, ueIdCb);
+     delete_ue_entries(ueIdCb->ue_id);
+     FW_FREE_MEM(fwCb, ueIdCb, sizeof(UeIdCb));
    }
 
 
@@ -2123,12 +2125,12 @@ PRIVATE S16 handlePdnDisConRejInd
       tmpNode = tmpNode->next;
    }
 
-   FW_LOG_DEBUG(fwCb, "\nStoping timer T3492\n");
-
-   if (flag == 1)
-   {
-      fwStopTmr(fwCb, ueIdCb);
-      ret = sendUePdnDisConRejIndToTstCntlr(uetPdnDisConRejInd);
+   if (flag == 1) {
+     FW_LOG_DEBUG(fwCb, "\nStoping timer T3492\n");
+     fwStopTmr(fwCb, ueIdCb);
+     delete_ue_entries(ueIdCb->ue_id);
+     FW_FREE_MEM(fwCb, ueIdCb, sizeof(UeIdCb));
+     ret = sendUePdnDisConRejIndToTstCntlr(uetPdnDisConRejInd);
    }
    else
    {

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1675,7 +1675,7 @@ PRIVATE S16 ueAppUtlAddEsmCb(UeEsmCb **esmCb, UeCb *ueCb)
       UE_LOG_ERROR(ueAppCb, "Failed to allocate memory\n");
       RETVALUE(RFAILED);
    }
-   for (i = 1; i < CM_ESM_MAX_BEARERS; i++)
+   for (i = 1; i < CM_ESM_MAX_BEARER_ID; i++)
    {
       if (ueCb->esmTList[i] == NULLP)
       {
@@ -1753,11 +1753,11 @@ PUBLIC S16 ueAppUtlFndEsmCb(UeEsmCb **esmCb, U8 key, UeAppEsmKeyType type,
    if (((key < UE_ESM_TRANS_ID_INDX) || (key > UE_ESM_MAX_TRANS_ID)))
       UE_LOG_EXITFN(ueAppCb, RFAILED);
 
-   if ((type == UE_ESM_TRANS_KEY) && (key < CM_ESM_MAX_BEARERS))
+   if ((type == UE_ESM_TRANS_KEY) && (key < CM_ESM_MAX_BEARER_ID))
    {
       *esmCb = ueCb->esmTList[key];
    }
-   else if ((type == UE_ESM_BID_KEY) && (key < CM_ESM_MAX_BEARERS))
+   else if ((type == UE_ESM_BID_KEY) && (key < CM_ESM_MAX_BEARER_ID))
    {
       *esmCb = ueCb->esmBList[key];
    }


### PR DESCRIPTION
## Title
Fixed printing of ue id multiple times

## Summary
This PR has the following fixes:
1. Ue Id was getting printed multiple times after receiving PDN Connection/Disconnection response as there were duplicate entries of the ue id in the ueIdList maintained at fwCb. Added a fix to clear the ue entry after processing the response
2. Old fix for CM_ESM_MAX_BEARER_ID supported was overwritten during one of the merges. Added the fix back.

## Test plan
1. Verified S1 SIM sanity
2. Verified test_attach_detach_secondary_pdn_with_pcscf_address.py and test_attach_detach_with_pcscf_address.py TCs
