### PR TITLE
[Enhancement] [Help] [UE_IP_Address_Allocation] Added guide note in README.md file for allocation of large number of UE IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ The following mask value, i.e., 24 needs to be changed in the file:
 TEST_IP_BLOCK = "192.168.128.0/24"
 ```
 
-Magma has reserved 12 IP addresses for internal testing purpose and therefore
-with the mask value of n, the maximum number of UE IP addresses allowed will be
+Magma has reserved 11 IP addresses for internal purpose and 2 IP addresses
+(Subnet Zero and All-Ones Subnet) are not allocatable. Therefore, with the mask
+value of n, the maximum number of UE IP addresses allowed will be
 ((2^(32-n)) - 13).
 
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ $ make
 On successful compilation, the “libtrfgen.so” library gets generated under
 Trfgen/lib folder.
 
+# Testing with Magma
+Following points should be considered when using S1APTester with
+[Magma](https://github.com/facebookincubator/magma)
+
+## UE IP Address Configuration
+While testing with [Magma](https://github.com/facebookincubator/magma) setup,
+the current configuration parameters in Magma allow allocation of only 243 UE
+IP addresses. We need to change the configuration in Magma codebase, in order
+to support allocation of more than 243 UE IP addresses.
+
+The following mask value, i.e., 24 needs to be changed in the file:
+[s1ap_wrapper.py](https://github.com/facebookincubator/magma/blob/master/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py)
+(Filepath: [magma/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py](https://github.com/facebookincubator/magma/blob/master/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py))
+```
+TEST_IP_BLOCK = "192.168.128.0/24"
+```
+
+Magma has reserved 12 IP addresses for internal testing purpose and therefore
+with the mask value of n, the maximum number of UE IP addresses allowed will be
+((2^(32-n)) - 13).
+
+```
+Example:
+For the mask value of 24, maximum number of allowed UE IP addresses = ((2^(32-24)) - 13) = 243
+For the mask value of 20, maximum number of allowed UE IP addresses = ((2^(32-20)) - 13) = 4083
+For the mask value of 17, maximum number of allowed UE IP addresses = ((2^(32-17)) - 13) = 32755
+```
+Decreasing the mask value will provide more number of UE IP addresses in the
+free IP address pool.
+
 ## License
 
 S1APTester is BSD License licensed, as found in the LICENSE file.


### PR DESCRIPTION
## Title
Added guide note in README.md file for allocation of large number of UE IP addresses

## Summary
While using S1APTester with Magma, the attach for more than 243 UEs is failing. The reason for the failure is that the configuration parameters in Magma have one hard-coded TEST_IP_BLOCK with a restricted number of allowed IP addresses. This PR adds the steps in Readme file, which needs to be followed to modify configuration in Magma, in order to allocate more than 243 UE IP addresses, along with some examples.