### PR TITLE
[Enhancement] Added support for attach of more than 256 UEs simultaneously

### DIFF
--- a/TestCntlrApp/src/cm/cm_hash.c
+++ b/TestCntlrApp/src/cm/cm_hash.c
@@ -1076,7 +1076,7 @@ U16          keyLen;       /* length of key */
 {
    CmHashListEnt *hashListEnt;    /* pointer to hash list entry header */
    PTR dupEntry;                  /* pointer to entry with duplicate key */
-   U16 idx;                       /* index for insertion into hash list */
+   U32 idx;                       /* index for insertion into hash list */
 
    TRC2(cmHashListInsert);
 

--- a/TestCntlrApp/src/cm/cm_lte.x
+++ b/TestCntlrApp/src/cm/cm_lte.x
@@ -30,7 +30,7 @@
 #include <cm_lte.h>
 /* Packing Defines */
 #define cmPkLteRbId              SPkU8
-#define cmPkLteRnti              SPkU16
+#define cmPkLteRnti              SPkU32
 #define cmPkLteCellId            SPkU16
 #define cmPkLteRlcMode           SPkU8
 #define cmPkLteLcId              SPkU8
@@ -39,7 +39,7 @@
 
 /* Unpacking Defines */
 #define cmUnpkLteRbId            SUnpkU8
-#define cmUnpkLteRnti            SUnpkU16
+#define cmUnpkLteRnti            SUnpkU32
 #define cmUnpkLteCellId          SUnpkU16
 #define cmUnpkLteRlcMode         SUnpkU8
 #define cmUnpkLteLcId            SUnpkU8
@@ -74,7 +74,7 @@ typedef U8    CmLteRbId;
 typedef U16   CmLteCellId;
 
 /** @brief RNTI */
-typedef U16   CmLteRnti;
+typedef U32   CmLteRnti;
 
 /** @brief Mode Type TM/UM/AM */
 typedef U8    CmLteRlcMode;

--- a/TestCntlrApp/src/cm/cm_umts.c
+++ b/TestCntlrApp/src/cm/cm_umts.c
@@ -333,7 +333,7 @@ Buffer *mBuf;     /* message buffer */
 #endif
 {
    TRC2(cmUnpkUmtsCrnti)
-   CMCHKUNPK(SUnpkU16, ueId , mBuf); 
+   CMCHKUNPK(SUnpkU32, ueId , mBuf);
    RETVALUE(ROK);
 }
 
@@ -859,7 +859,7 @@ Buffer *mBuf;
 #endif
 {
 TRC2(cmPkUmtsCrnti)
-CMCHKPK(SPkU16, *ueId, mBuf);
+CMCHKPK(SPkU32, *ueId, mBuf);
 RETVALUE(ROK);
 }
 

--- a/TestCntlrApp/src/cm/cm_umts.x
+++ b/TestCntlrApp/src/cm/cm_umts.x
@@ -40,7 +40,7 @@ EXTERN "C" {
 /* defination for Common UMTS */
 typedef U8 UmtsRbId;          /* Radio Bearer ID */
 typedef U32 UmtsUrnti;        /* Urnti UE Id */
-typedef U16 UmtsCrnti;        /* Crnti UE Id */
+typedef U32 UmtsCrnti;        /* Crnti UE Id */
 typedef U8 UmtsLogChType;     /* Logical Channel Type */
 typedef U8 UmtsRlcSvcType;    /* Rlc Service Type */
 typedef U8 UmtsOperatingMode; /* UMTS Operating Mode */

--- a/TestCntlrApp/src/cm/envopt.h
+++ b/TestCntlrApp/src/cm/envopt.h
@@ -126,15 +126,25 @@
 /* Flags that apply for the entire product are defined here */
 /* The legacy and the system services defintions are here   */
 #define USE_LINUX
+#define CMINET_BSDCOMPAT
 /* #define SS_TICKS_SEC        100 */
+#define CMFILE_REORG_1
+#define CMFILE_REORG_2
+#define CM_INET2
+#define SSINT2
 #undef HI_MULTI_THREADED 
+#define SS_PERF
 #define SS_WL_REGION        1
+#define SS_FLOAT
+#define SS_MT_TMR
 #define SS_M_PROTO_REGION
+#define SLES9_PLUS
 #undef SS_TSKLOG_ENABLE
 #define SS_MULTICORE_SUPPORT
 #undef  SS_USE_ICC_MEMORY
 #define SS_LOCKLESS_MEMORY
 #define SS_USE_ZBC_MEMORY
+#define SS_THR_REG_MAP
 #undef  SS_RBUF
 #undef  SS_LICENSE_CHECK
 #undef  SS_ROUTE_MSG_CORE1
@@ -142,12 +152,14 @@
 
 #undef  SSI_MEM_CORR_PREVENTION
 #undef  MS_MBUF_CORRUPTION
-
+//CHINNA
 #define TENB_MULT_CELL_SUPPRT
 
 /* LTE product specific definitions are here */
 #define TUCL_TTI_RCV
 #define LTE_PAL_ENB
+#define LTE_ENB_PAL
+#define TENB_RTLIN_CHANGES
 #define TENB_SPLIT_ARCH_SUPPORT
 #define TENB_SPLIT_ARCH
 #undef TENB_T2K3K_SPECIFIC_CHANGES
@@ -165,6 +177,8 @@
 
 #undef DAM_PDCP_OPT
 
+#define REL_850
+#define TA_NEW
 #undef TENB_FP
 #if defined(MODE) && (MODE==TDD)
 #define LTE_TDD 1
@@ -252,9 +266,16 @@
 /* SZT interface (App<->S1AP) flags */
 #define SZTV1
 #define SZTV2
+#define SZTV3
+
+/* CZT interface (App<->X2AP) flags */
+#define CZTV1
 
 /* LSZ interface (SM<->S1AP) flags */
 #define LSZV1
+
+/* LEG interface (SM<->EGTP) flags */
+#define LEGV2
 
 /* CTF interface (App<->CL) flags */
 #define CTF_VER3
@@ -277,12 +298,15 @@
 #define RGR_V1
 #define RGR_V2
 #define RGR_CQI_REPT
+#define RGR_SI_SCH
 #define RGR_RRM_TICK
 
 /* RRM related interface flags */
 #define RM_INTF
 
 /* LSB interface flags */
+#define LSB4
+#define LSB8
 #define SB_CHECKSUM   /* Define to include trillium supplied function */
 #define SB_CHECKSUM_CRC 
 
@@ -413,6 +437,7 @@
 #endif
 
 /* product options */
+#define SZ_ENB
 #define CM_PASN_CRIT_HANDL
 #undef  M_PASN_DBG
 #undef S1AP_REL851
@@ -420,6 +445,8 @@
 #define SZ_USTA
 
 /* interface options */
+#define LCSZUISZT     /* loosely coupled, SZ upper layer SZT interface */
+#define LCSZMILSZ     /* loosely coupled, SZ manegement  LSZ interface */
 #define LCSZLISCT     /* loosely coupled, SZ lower layer SCT interface */
 
 /* Based on the selection of coupling above the section below  */
@@ -487,7 +514,10 @@
 /* not talk to TUCL on HIT in the latest TeNB. However if it were  */
 /* to use TUCL, it would be loosely coupled as TUCL is multi-      */
 /* threaded.                                                       */
+/* TODO - LCEGUIEGT should not be needed.                          */
 #define LCSMEGMILEG
+#define LCEGLIHIT
+#define LCEGUIEGT
 #define LCEGMILEG
 
 /* Managing the loose coupling definitions on the interface based   */
@@ -1369,6 +1399,8 @@
 
 /* We need to define LCHIUIHIT if there is at least one layer talking */
 /* to TUCL in a loosely coupled fashion.                              */
+#define LCHIUIHIT
+#define LCHIMILHI
 
 /* The section below should not be edited normally.                   */
 #ifdef LCHIUIHIT

--- a/TestCntlrApp/src/cm/envopt.h
+++ b/TestCntlrApp/src/cm/envopt.h
@@ -126,25 +126,15 @@
 /* Flags that apply for the entire product are defined here */
 /* The legacy and the system services defintions are here   */
 #define USE_LINUX
-#define CMINET_BSDCOMPAT
 /* #define SS_TICKS_SEC        100 */
-#define CMFILE_REORG_1
-#define CMFILE_REORG_2
-#define CM_INET2
-#define SSINT2
 #undef HI_MULTI_THREADED 
-#define SS_PERF
 #define SS_WL_REGION        1
-#define SS_FLOAT
-#define SS_MT_TMR
 #define SS_M_PROTO_REGION
-#define SLES9_PLUS
 #undef SS_TSKLOG_ENABLE
 #define SS_MULTICORE_SUPPORT
 #undef  SS_USE_ICC_MEMORY
 #define SS_LOCKLESS_MEMORY
 #define SS_USE_ZBC_MEMORY
-#define SS_THR_REG_MAP
 #undef  SS_RBUF
 #undef  SS_LICENSE_CHECK
 #undef  SS_ROUTE_MSG_CORE1
@@ -152,14 +142,12 @@
 
 #undef  SSI_MEM_CORR_PREVENTION
 #undef  MS_MBUF_CORRUPTION
-//CHINNA
+
 #define TENB_MULT_CELL_SUPPRT
 
 /* LTE product specific definitions are here */
 #define TUCL_TTI_RCV
 #define LTE_PAL_ENB
-#define LTE_ENB_PAL
-#define TENB_RTLIN_CHANGES
 #define TENB_SPLIT_ARCH_SUPPORT
 #define TENB_SPLIT_ARCH
 #undef TENB_T2K3K_SPECIFIC_CHANGES
@@ -177,8 +165,6 @@
 
 #undef DAM_PDCP_OPT
 
-#define REL_850
-#define TA_NEW
 #undef TENB_FP
 #if defined(MODE) && (MODE==TDD)
 #define LTE_TDD 1
@@ -266,16 +252,9 @@
 /* SZT interface (App<->S1AP) flags */
 #define SZTV1
 #define SZTV2
-#define SZTV3
-
-/* CZT interface (App<->X2AP) flags */
-#define CZTV1
 
 /* LSZ interface (SM<->S1AP) flags */
 #define LSZV1
-
-/* LEG interface (SM<->EGTP) flags */
-#define LEGV2
 
 /* CTF interface (App<->CL) flags */
 #define CTF_VER3
@@ -298,15 +277,12 @@
 #define RGR_V1
 #define RGR_V2
 #define RGR_CQI_REPT
-#define RGR_SI_SCH
 #define RGR_RRM_TICK
 
 /* RRM related interface flags */
 #define RM_INTF
 
 /* LSB interface flags */
-#define LSB4
-#define LSB8
 #define SB_CHECKSUM   /* Define to include trillium supplied function */
 #define SB_CHECKSUM_CRC 
 
@@ -437,7 +413,6 @@
 #endif
 
 /* product options */
-#define SZ_ENB
 #define CM_PASN_CRIT_HANDL
 #undef  M_PASN_DBG
 #undef S1AP_REL851
@@ -445,8 +420,6 @@
 #define SZ_USTA
 
 /* interface options */
-#define LCSZUISZT     /* loosely coupled, SZ upper layer SZT interface */
-#define LCSZMILSZ     /* loosely coupled, SZ manegement  LSZ interface */
 #define LCSZLISCT     /* loosely coupled, SZ lower layer SCT interface */
 
 /* Based on the selection of coupling above the section below  */
@@ -514,10 +487,7 @@
 /* not talk to TUCL on HIT in the latest TeNB. However if it were  */
 /* to use TUCL, it would be loosely coupled as TUCL is multi-      */
 /* threaded.                                                       */
-/* TODO - LCEGUIEGT should not be needed.                          */
 #define LCSMEGMILEG
-#define LCEGLIHIT
-#define LCEGUIEGT
 #define LCEGMILEG
 
 /* Managing the loose coupling definitions on the interface based   */
@@ -1399,8 +1369,6 @@
 
 /* We need to define LCHIUIHIT if there is at least one layer talking */
 /* to TUCL in a loosely coupled fashion.                              */
-#define LCHIUIHIT
-#define LCHIMILHI
 
 /* The section below should not be edited normally.                   */
 #ifdef LCHIUIHIT

--- a/TestCntlrApp/src/cm/lcz.c
+++ b/TestCntlrApp/src/cm/lcz.c
@@ -4880,7 +4880,7 @@ Buffer *mBuf;
 
    TRC3(cmPkCzUeInfo)
 
-   CMCHKPK(SPkU16, param->ueId, mBuf);
+   CMCHKPK(SPkU32, param->ueId, mBuf);
    CMCHKPK(SPkU32, param->peerId, mBuf);
    RETVALUE(ROK);
 }
@@ -4921,7 +4921,7 @@ Buffer *mBuf;
    TRC3(cmUnpkCzUeInfo)
 
    CMCHKUNPK(SUnpkU32, &param->peerId, mBuf);
-   CMCHKUNPK(SUnpkU16, &param->ueId, mBuf);
+   CMCHKUNPK(SUnpkU32, &param->ueId, mBuf);
    RETVALUE(ROK);
 }
 

--- a/TestCntlrApp/src/cm/lcz.x
+++ b/TestCntlrApp/src/cm/lcz.x
@@ -760,7 +760,7 @@ typedef struct czPeerInfo
 typedef struct czUeInfo
 {
  U32 peerId;             /**< Peer identifier. */
- U16 ueId;               /**< UE identifier. */
+ U32 ueId;               /**< UE identifier. */
 }CzUeInfo;
 
 /** 

--- a/TestCntlrApp/src/cm/lcz_sample.x
+++ b/TestCntlrApp/src/cm/lcz_sample.x
@@ -720,7 +720,7 @@ CzStsUnion u;
 struct CzUeInfo
 {
  U32 peerId;            /**< Peer Identifier */
- U16 ueId;              /**< UE Identifier */
+ U32 ueId;              /**< UE Identifier */
 };
 
 union CzUstaDgnUnion

--- a/TestCntlrApp/src/cm/lkw.c
+++ b/TestCntlrApp/src/cm/lkw.c
@@ -2651,7 +2651,7 @@ Buffer *mBuf;
          }
          CMCHKPK(SPkU8, param->val.ipThMeas.ueInfoLst[idx1].numQci, mBuf);
       }
-      CMCHKPK(SPkU16, param->val.ipThMeas.numUes, mBuf);
+      CMCHKPK(SPkU32, param->val.ipThMeas.numUes, mBuf);
       CMCHKPK(SPkU8, param->measType, mBuf);
       RETVALUE(ROK);
    }

--- a/TestCntlrApp/src/cm/lkw.x
+++ b/TestCntlrApp/src/cm/lkw.x
@@ -268,7 +268,7 @@ typedef struct kwL2MeasReqInfo
 
       struct 
       {
-         U16 numUes;
+         U32 numUes;
          struct 
          {
             U8           numQci;           /*!<number of qCI to take measurement for */

--- a/TestCntlrApp/src/cm/lnh.c
+++ b/TestCntlrApp/src/cm/lnh.c
@@ -522,7 +522,7 @@ Buffer *mBuf;
           break;
        case LNH_USTA_DGNVAL_CELLUEID :
           CMCHKPK(SPkU16, param->u.cellUeId.cellId,mBuf);
-          CMCHKPK(SPkU16, param->u.cellUeId.ueId,mBuf);
+          CMCHKPK(SPkU32, param->u.cellUeId.ueId,mBuf);
           break; 
        default:
           break;
@@ -2086,7 +2086,7 @@ Buffer *mBuf;
           CMCHKUNPK(SUnpkU8, &param->u.tId,mBuf);
           break;
        case LNH_USTA_DGNVAL_CELLUEID :
-          CMCHKUNPK(SUnpkU16, &param->u.cellUeId.ueId,mBuf);
+          CMCHKUNPK(SUnpkU32, &param->u.cellUeId.ueId,mBuf);
           CMCHKUNPK(SUnpkU16, &param->u.cellUeId.cellId,mBuf);
           break; 
        default:

--- a/TestCntlrApp/src/cm/lnh.x
+++ b/TestCntlrApp/src/cm/lnh.x
@@ -291,7 +291,7 @@ typedef struct nhSapInfo
 /** @brief Cell and UE ID structure parameters */
 typedef struct nhCellUEId
 {
-   U16        ueId;         /*!< UE ID */
+   U32        ueId;         /*!< UE ID */
    U16        cellId;       /*!< Cell ID */
 }NhCellUEId;
 /**

--- a/TestCntlrApp/src/cm/lve.c
+++ b/TestCntlrApp/src/cm/lve.c
@@ -311,7 +311,7 @@ Buffer *mBuf;
           break;
        case LVE_USTA_DGNVAL_CELLUEID :
           CMCHKPK(SPkU16, param->u.s.cellId,mBuf);
-          CMCHKPK(SPkU16, param->u.s.ueId,mBuf);
+          CMCHKPK(SPkU32, param->u.s.ueId,mBuf);
           break; 
        default:
           break;
@@ -1083,7 +1083,7 @@ Buffer *mBuf;
           CMCHKUNPK(SUnpkS16, &param->u.sapId,mBuf);
           break;
        case LVE_USTA_DGNVAL_CELLUEID :
-          CMCHKUNPK(SUnpkU16, &param->u.s.ueId,mBuf);
+          CMCHKUNPK(SUnpkU32, &param->u.s.ueId,mBuf);
           CMCHKUNPK(SUnpkU16, &param->u.s.cellId,mBuf);
           break; 
        default:

--- a/TestCntlrApp/src/cm/nhu.x
+++ b/TestCntlrApp/src/cm/nhu.x
@@ -73,7 +73,7 @@ typedef U8 NhuPdcpId;
  * @brief NhuCrnti
    Crnti. Required to create an UE context. 
 */
-typedef U32 NhuCrnti;      
+typedef U32 NhuCrnti;
 
 /**
  * @brief NhuCellId

--- a/TestCntlrApp/src/cm/nhu.x
+++ b/TestCntlrApp/src/cm/nhu.x
@@ -73,7 +73,7 @@ typedef U8 NhuPdcpId;
  * @brief NhuCrnti
    Crnti. Required to create an UE context. 
 */
-typedef U16 NhuCrnti;      
+typedef U32 NhuCrnti;      
 
 /**
  * @brief NhuCellId

--- a/TestCntlrApp/src/cm/nlu.x
+++ b/TestCntlrApp/src/cm/nlu.x
@@ -182,8 +182,8 @@ typedef struct nluUeInfo
    NluUeEvent         event;  /*!< indicate what type of events either add new 
                                    UE or delete UE*/
    NluEcgi            ecgi;   /*!< ECGI, cell to which the UE is attached */
-   U16                crnti;  /*!< Unique identity of the UE */
-   U16                oldCrnti;  /*!< Old Unique identity of the UE */
+   U32                crnti;  /*!< Unique identity of the UE */
+   U32                oldCrnti;  /*!< Old Unique identity of the UE */
 }NluUeInfo;
 
 EXTERN S16 NlUiNluUeInd   ARGS((
@@ -215,7 +215,7 @@ typedef struct nluNghCellMeasRpt
 typedef struct nluUeMeasRpt
 {
    NluEcgi            ecgi;   /*!< ECGI, unique Identity of the eNB */
-   U16                crnti;  /*!< Unique identity of the UE */
+   U32                crnti;  /*!< Unique identity of the UE */
 #if 0   
    S16                nghCellRsrp;  /*!< RSRP of neighbor cell*/
    S16                servCellRsrp;  /*!< serv cell RSRP*/

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -40,10 +40,10 @@ EXTERN U8 uesLocalRel;
 PUBLIC S16 NbEnbUeCtxtRelForInitCtxtSetup(NbSendUeCtxtRelForICSRsp *sendUeCtxtRelReq);
 PUBLIC S16 NbEnbDelayInitCtxtSetupRsp(NbDelayICSRsp *delayICSRsp);
 PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup);
-PUBLIC S16 nbDelUeCb(U8 ueId);
+PUBLIC S16 nbDelUeCb(U32 ueId);
 PUBLIC S16 nbUeTnlCreatCfm(U8, U32);
-PUBLIC S16 nbPrcDamUeDelCfm(U8);
-PUBLIC S16 nbCreateUeTunnReq(U8, U32, U8, NbuUeIpInfoRsp *);
+PUBLIC S16 nbPrcDamUeDelCfm(U32);
+PUBLIC S16 nbCreateUeTunnReq(U32, U32, U8, NbuUeIpInfoRsp *);
 PUBLIC S16 NbEnbUeRelReqHdl(NbUeCntxtRelReq*);
 PUBLIC S16 NbEnbResetReqHdl(NbResetRequest *resetReq);
 /*PUBLIC S16 NbEnbErabRelIndHdl(NbErabRelInd *erabRelInd);*/
@@ -53,7 +53,7 @@ PUBLIC S16 NbEnbNasNonDel(NbNasNonDel *nasNonDel);
 PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail);
 
 EXTERN S16 nbIfmDamTnlCreatReq(NbDamTnlInfo*);
-EXTERN S16 nbIfmDamUeRelReq(U16, U8);
+EXTERN S16 nbIfmDamUeRelReq(U32, U8);
 EXTERN S16 nbAppRouteInit(U32 selfIp, S8*);
 
 EXTERN NbDamCb nbDamCb;
@@ -275,7 +275,7 @@ PUBLIC S16 nbPrcResetAck
    U32 mmeUeS1apId = 0;
    U32 enbUeS1apId = 0;
    U16 cnt = 0;
-   U8 ueId = 0;
+   U32 ueId = 0;
    NbResetAckldg nbResetAck = {0};
    SztSuccessfulOutcome *succMsg  = &pdu->pdu.val.successfulOutcome;
    SztResetAckg *resetAck = &succMsg->value.u.sztResetAckg;
@@ -294,7 +294,7 @@ PUBLIC S16 nbPrcResetAck
             if(numComp)
             {
                nbResetAck.numOfUes = numComp;
-               NB_ALLOC(&nbResetAck.ueIdLst, numComp);
+               NB_ALLOC(&nbResetAck.ueIdLst, numComp * sizeof(U32));
             }
             for(cnt = 0; cnt < numComp; cnt++)
             {
@@ -320,11 +320,11 @@ PUBLIC S16 nbPrcResetAck
 
    if(nbUiSendResetAckToUser(&nbResetAck) != ROK)
    {
-      NB_FREE(nbResetAck.ueIdLst, nbResetAck.numOfUes);
+      NB_FREE(nbResetAck.ueIdLst, nbResetAck.numOfUes * sizeof(U32));
       NB_LOG_EXITFN(&nbCb, RFAILED);
    }
 
-   NB_FREE(nbResetAck.ueIdLst, nbResetAck.numOfUes);
+   NB_FREE(nbResetAck.ueIdLst, nbResetAck.numOfUes * sizeof(U32));
    uesLocalRel = FALSE;
    UNUSED(peerId);
 
@@ -410,7 +410,7 @@ PUBLIC S16 nbUeTnlCreatCfm(U8 status, U32 lclTeid)
    RETVALUE(ret);
 }
 
-PUBLIC S16 nbPrcDamUeDelCfm(U8 ueId)
+PUBLIC S16 nbPrcDamUeDelCfm(U32 ueId)
 {
    S16 ret = ROK;
 
@@ -421,7 +421,7 @@ PUBLIC S16 nbPrcDamUeDelCfm(U8 ueId)
    RETVALUE(ret);
 }
 
-PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr, U8 bearerId,
+PUBLIC S16 nbCreateUeTunnReq(U32 ueId, U32 ueIpAddr, U8 bearerId,
                              NbuUeIpInfoRsp *rsp)
 {
   U8 idx = 0;
@@ -433,7 +433,7 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr, U8 bearerId,
   NbUeTunInfo *tunInfo = NULLP;
 
   NB_LOG_ENTERFN(&nbCb);
-  if (ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId), sizeof(U8), 0,
+  if (ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId), sizeof(U32), 0,
                              (PTR *)&ueCb))) {
     RETVALUE(RFAILED);
   }
@@ -465,7 +465,7 @@ PUBLIC S16 nbCreateUeTunnReq(U8 ueId, U32 ueIpAddr, U8 bearerId,
   RETVALUE(RFAILED);
 }
 
-PUBLIC S16 nbDelUeCb(U8 ueId)
+PUBLIC S16 nbDelUeCb(U32 ueId)
 {
 
    S16 ret = RFAILED;
@@ -499,7 +499,7 @@ PUBLIC S16 nbDelUeCb(U8 ueId)
    }
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       ret = RFAILED;
    }
@@ -589,7 +589,7 @@ PUBLIC Void nbHandleUeDelReq(NbUeCb *ueCb)
  */
 PUBLIC S16 nbSndCtxtRelReq
 (
- U8                           ueId,
+ U32                           ueId,
  NbUeMsgCause                 *relCause
 )
 {
@@ -617,7 +617,7 @@ PUBLIC S16 nbSndCtxtRelReq
    }
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb,"ueCb not found");
       RETVALUE(RFAILED);
@@ -823,13 +823,13 @@ PUBLIC S16 NbEnbUeRelReqHdl
 
 PRIVATE S16 getS1apInfoFrmUeId
 (
- U8 *ueIdLst,
- U16 numOfUes,
+ U32 *ueIdLst,
+ U32 numOfUes,
  NbResetMsgInfo *resetMsg
 )
 {
-   U16 cnt = 0;
-   U8 ueId = 0;
+   U32 cnt = 0;
+   U32 ueId = 0;
    NbUeCb *ueCb = NULLP;
 
    NB_LOG_ENTERFN(&nbCb);
@@ -848,7 +848,7 @@ PRIVATE S16 getS1apInfoFrmUeId
    {
       ueId = ueIdLst[cnt];
       if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
       {
          NB_LOG_ERROR(&nbCb, "UeCb not found for UeId %d", ueIdLst[cnt]);
       }
@@ -864,7 +864,7 @@ PUBLIC S16 NbEnbResetReqHdl
  NbResetRequest *resetReq
 )
 {
-   U8 idx = 0;
+   U32 idx = 0;
    S16 ret = ROK;
    NbUeCb *ueCb = NULLP, *prev = NULLP;
    NbResetMsgInfo resetMsgInfo = {0};
@@ -964,7 +964,7 @@ PUBLIC S16 NbEnbErabRelIndHdl
 
    /* Find the ENB and MME UE-S1AP Ids using UeId */
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(erabRelInd->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       RETVALUE(RFAILED);
    }
@@ -1005,7 +1005,7 @@ PUBLIC S16 NbEnbErabRelRspHdl
 
    /* Find the ENB and MME UE-S1AP Ids using UeId */
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(erabRelRsp->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb, "UeCb not found for UeId %d", erabRelRsp->ueId);
       NB_LOG_EXITFN(&nbCb, RFAILED);
@@ -1276,7 +1276,7 @@ PUBLIC S16 NbEnbX2HOTriggerReqHdl
       RETVALUE(RFAILED);
    }
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(x2HOTriggerReq->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb, "UeCb not found for UeId %d", x2HOTriggerReq->ueId);
       NB_LOG_EXITFN(&nbCb, RFAILED);
@@ -1404,7 +1404,7 @@ PUBLIC S16 NbEnbConfigTransferHdl
    NbUeCb       *ueCb   = NULLP;
 
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(enbConfigTrnsf->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb, "UeCb not found for UeId %d", enbConfigTrnsf->ueId);
       NB_LOG_EXITFN(&nbCb, RFAILED);

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -240,7 +240,7 @@ typedef struct _nbFailedErabLst {
 
 typedef struct _nbErabRelLst
 {
-   U8 ueId;
+   U32 ueId;
    U32 mmeUeS1apId;
    U32 enbUeS1apId;
    U8 numOfErabIds;
@@ -250,14 +250,14 @@ typedef struct _nbErabRelLst
 
 typedef struct _nbDelayICSRspCb
 {
- U8 ueId;
+ U32 ueId;
  NbErabLst *erabInfo;
  CmTimer   timer;
 }NbDelayICSRspCb;
 
 typedef struct _nbDelayUeCtxtRelCmpCb
 {
- U8 ueId;
+ U32 ueId;
  CmTimer   timer;
 }NbDelayUeCtxtRelCmpCb;
 
@@ -303,7 +303,7 @@ struct _nbUeCb
 {
    CmHashListEnt ueHashEnt;
    U32 ueId;
-   U8  ueIdx;
+   U32  ueIdx;
    NbS1ConCb   *s1ConCb;
    U8 tunnIdx;
 #if 0
@@ -360,7 +360,7 @@ typedef struct _nbTai
 
 typedef struct _NbTmrCfg
 {
-   U16                       s1SetupTmr;
+   U32                       s1SetupTmr;
 }NbTmrCfg;
 
 typedef struct _nbMmeName
@@ -512,7 +512,7 @@ typedef struct _nbResetMsgInfo
 {
    U8 type;
    NbUeMsgCause cause;
-   U16 s1apIdCnt;
+   U32 s1apIdCnt;
    U32 *enbUeS1apIdLst;
    U32 *mmeUeS1apIdLst;
    U32 enbId;
@@ -521,8 +521,8 @@ typedef struct _nbResetMsgInfo
 typedef struct _nbResetAck
 {
    U8 status;
-   U16 numOfUes;
-   U8 *ueIdLst;
+   U32 numOfUes;
+   U32 *ueIdLst;
 }NbResetAck;
 
 #define NB_GET_S1AP_CON_ID(_suConId,_ptr) {\
@@ -675,7 +675,7 @@ EXTERN Void nbStopTmr(PTR cb, S16 event);
 
 EXTERN Bool nbIsTmrRunning(CmTimer *tmr, S16 event);
 
-EXTERN  Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId);
+EXTERN  Void nbHandleUeIpInfoReq(U32 ueId,U8 bearerId);
 
 EXTERN Void nbSendLmAlarm(U16 category, U16 event, U16 cause);
 
@@ -690,7 +690,7 @@ EXTERN S16 nbUiBuildAndSendPagingMsg(NbPagingMsgInfo *pagMsgInfo);
 EXTERN S16 nbSendInitCtxtSetupRcvInd(NbUeCb *ueCb, NbErabLst *erabInfo,
       Bool ueRadCapRcvd);
 
-EXTERN S16 nbSendS1RelIndToUeApp(U8 ueId);
+EXTERN S16 nbSendS1RelIndToUeApp(U32 ueId);
 
 EXTERN S16 nbBuildAndSendS1SetupReq(NbMmeId mmeId);
 
@@ -770,9 +770,9 @@ EXTERN S16 nbS1apFillEutranCgi(S1apPdu *pdu, SztEUTRAN_CGI *cgiIe);
 EXTERN S16 nbSendErabsInfo(NbUeCb *ueCb, NbErabLst *erabInfo,
                            NbFailedErabLst *failedErabInfo, Bool ueRadCapRcvd);
 
-EXTERN Void nbUiNbuHandleUeInactivity(U8 ueId);
+EXTERN Void nbUiNbuHandleUeInactivity(U32 ueId);
 
-EXTERN Void nbDamSetDatFlag(U8 ueId);
+EXTERN Void nbDamSetDatFlag(U32 ueId);
 
 EXTERN S16 nbFillTknStrOSXL1(TknStrOSXL *ptr, U16 len, U32 val,
       CmMemListCp *mem);
@@ -782,7 +782,7 @@ EXTERN S16 nbS1apFillCtxtRelReq(NbUeCb *ueCb, S1apPdu **pdu,
 
 EXTERN Void nbHandleUeDelReq(NbUeCb *ueCb);
 
-EXTERN S16 nbSndCtxtRelReq(U8 ueId, NbUeMsgCause *relCause);
+EXTERN S16 nbSndCtxtRelReq(U32 ueId, NbUeMsgCause *relCause);
 
 EXTERN S16 NbIfmS1apRelReq(SztRelReq *relReq);
 
@@ -792,7 +792,7 @@ EXTERN Void nbUiSendS1TimeOutInd(Void);
 
 EXTERN Void nbUiSendS1SetupFailInd(U8 causeType,U32 causeVal,U32 wait);
 
-EXTERN Void nbRelCntxtInTrafficHandler(U8 ueId);
+EXTERN Void nbRelCntxtInTrafficHandler(U32 ueId);
 EXTERN S16 nbHandleDelayTimerForICSExpiry(NbDelayICSRspCb *icsRspCb);
 
 EXTERN S16 nbPrcInitPdu(U32 peerId, S1apPdu *pdu);
@@ -808,11 +808,11 @@ PUBLIC Bool nbPlmnPlmnsEqual(NbPlmnId *plmnId1, NbPlmnId *plmnId2);
 PUBLIC S16 nbUpdateUePagInfo(S1apPdu *s1apPagMsg, NbPagingMsgInfo *uePagingInfo,
       SztTAILst **pagMsgTAILst, SztCSG_IdLst **pagMsgCSG_IdLst);
 
-PUBLIC S16 nbUiBuildAndSendNasNonDlvryIndToTfw( U8 ueId );
+PUBLIC S16 nbUiBuildAndSendNasNonDlvryIndToTfw( U32 ueId );
 
 EXTERN S16 nbSendErabsRelInfo(NbErabRelLst *erabInfo);
 
-EXTERN  S16 nbNotifyPlmnInfo(U8 ueId, NbPlmnId plmnId);
+EXTERN  S16 nbNotifyPlmnInfo(U32 ueId, NbPlmnId plmnId);
 /* Broadcasted PLMN List */
 typedef struct _nbBPlmnList
 {

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -42,7 +42,7 @@ PRIVATE S16 nbDamLSapCntrl(LnbCntrl *sapCntrl,CmStatus *status,Elmnt elmnt);
 PRIVATE S16 nbDamBndLSap (NbLiSapCb *sapCb,CmStatus  *status,Elmnt elmnt);
 PRIVATE S16 nbDamUbndLSap (NbLiSapCb  *sapCb);
 PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId);
-PUBLIC  NbDamUeCb *nbDamGetUe(U8 ueId);
+PUBLIC  NbDamUeCb *nbDamGetUe(U32 ueId);
 PUBLIC S16 nbDamEgtpDatInd(Pst*, EgtUEvnt*);
 
 /* Some basic default values used for E-GTP Tunnel Management*/
@@ -217,7 +217,7 @@ PUBLIC Void nbDamTnlMgmtCfm
 )
 {
    NbDamTnlCb                *tnlCb = NULLP;
-   U8                        ueId;
+   U32                        ueId;
    U8                        rbId;
    NbDamUeCb                 *ueCb;
    NbDamDrbCb                *drbCb;
@@ -307,7 +307,7 @@ PUBLIC Void nbDamTnlMgmtCfm
  */
 PUBLIC S16 nbDamDelUe
 (
- U8 ueId 
+ U32 ueId
 )
 {
    S16 ret = ROK;
@@ -337,7 +337,7 @@ PUBLIC S16 nbDamDelUe
    }
 #endif
    if(ROK != (cmHashListFind(&(nbDamCb.ueCbs), (U8 *)&(ueId),
-      sizeof(U8), 0, (PTR *)&ueCb)))
+      sizeof(U32), 0, (PTR *)&ueCb)))
    {   
       ret = RFAILED;
    }
@@ -387,7 +387,7 @@ PUBLIC S16 nbDamDelUe
  *    -#Success : ROK
  *    -#Failure : RFAILED
  */
-PRIVATE S16 nbDamAddUe(NbDamUeCb **ueCb, U8 ueId)
+PRIVATE S16 nbDamAddUe(NbDamUeCb **ueCb, U32 ueId)
 {
   NbDamDrbCb tmpDamDrbCb;
   NbIpInfo tmpDamIpInfo;
@@ -445,7 +445,7 @@ PRIVATE S16 nbDamAddUe(NbDamUeCb **ueCb, U8 ueId)
 
   cmLListInit(&(pdnCb.tftPfList));
   if (ROK != cmHashListInsert(&(nbDamCb.ueCbs), (PTR) * (ueCb),
-                              (U8 *)&(*ueCb)->ueId, sizeof(U8))) {
+                              (U8 *)&(*ueCb)->ueId, sizeof(U32))) {
     /* deinit the ip list and drblist */
     NB_FREE(*ueCb, sizeof(NbDamUeCb))
     NB_LOG_ERROR(&nbCb, "Failed to Insert UE into UeDamCbLst");
@@ -650,7 +650,7 @@ PRIVATE S16 nbDamAddTunnel
 NbDamTnlInfo                 *tnlInfo
 )
 {
-   U8 ueId;
+   U32 ueId;
    NbDamUeCb       *ueCb = NULLP;
    NbDamTnlCb      *tnlCb  = NULLP;
    U8              rbId    = tnlInfo->tnlId.drbId;
@@ -1042,7 +1042,7 @@ EgtUEvnt                     *eguMsg
    NbDamTnlCb                *tnlCb = NULLP;
    NbDamUeCb                 *ueCb = NULLP;
    NbDamDrbCb                *drbCb = NULLP;
-   U16                       ueId;
+   U32                       ueId;
    CmLteRbId                 rbId;        /*!< PDCP Instance ID */
 
    MsgLen                    len       = 0;
@@ -1148,7 +1148,7 @@ EgtUEvnt                     *eguMsg
  */
 PUBLIC Void nbDamUeDelReq
 (
- U8  ueId
+ U32  ueId
 )
 {
    NbDamUeCb *ueCb = NULLP;
@@ -1950,11 +1950,11 @@ PRIVATE NbDamUeCb *nbDamGetueCbkeyUeIp(NbIpPktFields *ipPktFields, U8 *drbId)
   RETVALUE(ueCb);
 }
 
-PUBLIC NbDamUeCb* nbDamGetUe(U8 ueId)
+PUBLIC NbDamUeCb* nbDamGetUe(U32 ueId)
 {
    NbDamUeCb *ueCb = NULLP;
    if ( ROK != (cmHashListFind(&(nbDamCb.ueCbs), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {    
       RETVALUE(NULLP);
    }
@@ -1962,7 +1962,7 @@ PUBLIC NbDamUeCb* nbDamGetUe(U8 ueId)
    RETVALUE(ueCb);
 }
 
-PUBLIC Void nbDamSetDatFlag(U8 ueId)
+PUBLIC Void nbDamSetDatFlag(U32 ueId)
 {
    NbDamUeCb *ueCb = NULLP;
    ueCb = nbDamGetUe(ueId);

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -217,7 +217,7 @@ PUBLIC Void nbDamTnlMgmtCfm
 )
 {
    NbDamTnlCb                *tnlCb = NULLP;
-   U32                        ueId;
+   U32                       ueId;
    U8                        rbId;
    NbDamUeCb                 *ueCb;
    NbDamDrbCb                *drbCb;

--- a/TestCntlrApp/src/enbApp/nb_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_dam.h
@@ -188,9 +188,9 @@ typedef struct nbDamDrbCb
  * @details These are the structure members
  * - CmTimer        inactivityTmr  inactivity timer structure
  * - CmTimer        endMrkTmr      end marker timer structure
- * - U16            ueId           unique UE ID
+ * - U32            ueId           unique UE ID
  * - U16            cellId         Cell ID in which UE is present
- * - U16            ueIdx          UE Index
+ * - U32            ueIdx          UE Index
  * - Bool           dataRcvd       flag to indicate if ue has been active
  * - U8             reestabInProgress Flag to indicate if UE is under
  *                                    reestablishment
@@ -294,7 +294,7 @@ typedef struct nbPdnCb {
 typedef struct nbDamUeCb {
   CmHashListEnt ueHashEnt;
   CmTimer inactivityTmr;
-  U16 ueId;
+  U32 ueId;
   U16 expiryCnt;
   U8 ueState;
   U8 dataRcvd;
@@ -317,7 +317,7 @@ typedef struct nbDamUeCb {
 typedef struct nbDamUeIdx
 {
    CmLList                   lnk;
-   U16                       idx;
+   U32                       idx;
    NbDamUeCb                 *ueCb;
 } NbDamUeIdx;
 
@@ -334,7 +334,7 @@ typedef struct nbDamUeIdxCp
 {
    CmLListCp                freeLst;
    CmLListCp                inuseLst;
-   U16                      numIdxs;
+   U32                      numIdxs;
    NbDamUeIdx               *idxs;
 } NbDamUeIdxCp;
 
@@ -354,8 +354,8 @@ typedef struct nbDamCellCb
 {
    U8                        cellInUse;
    U8                        cellId;
-   U16                       startRnti;
-   U16                       numRntis;
+   U32                       startRnti;
+   U32                       numRntis;
    NbDamUeIdxCp              ueIdxCp;
    NbDamUeCb                 **ueCbs;
 } NbDamCellCb;
@@ -491,9 +491,9 @@ EXTERN NbDamCb               nbDamCb;
 
 EXTERN S16 nbDamStartUeInactvTmr(NbDamUeCb*);
 EXTERN Void nbDamTnlMgmtCfm(EgtUEvnt*);
-EXTERN S16 nbDamDelUe(U8);
+EXTERN S16 nbDamDelUe(U32);
 EXTERN S16 nbDamPcapDatInd(Buffer*);
-EXTERN Void nbDamUeDelReq(U8);
+EXTERN Void nbDamUeDelReq(U32);
 EXTERN Void nbDamNbErabDelReq(NbuErabRelIndList*);
 EXTERN S16 nbDamInit(Void);
 EXTERN S16 nbDamActvInit(Ent, Inst, Region, Reason);
@@ -511,7 +511,7 @@ EXTERN S16  nbDamActvTmr(Void);
 EXTERN S16  nbDamStartTmr(PTR cb, S16 tmrEvnt, U32 delay);
 EXTERN Void nbDamStopTmr(PTR cb, S16 event);
 EXTERN S16 nbIfmDamEgtpErrInd(U32 lclTeid, U32 numDrbs, U16 crnti);
-EXTERN Void nbDamSetDataRcvdFlag (U16 cellId, U16 ueId);
+EXTERN Void nbDamSetDataRcvdFlag (U16 cellId, U32 ueId);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/TestCntlrApp/src/enbApp/nb_dam_ifm_app.c
+++ b/TestCntlrApp/src/enbApp/nb_dam_ifm_app.c
@@ -325,7 +325,7 @@ PUBLIC S16 nbIfmDamNbTnlDelCfm
  */
 PUBLIC Void nbIfmDamNbCtxtRel
 (
-U32                     ueId,
+U32                    ueId,
 U8                     causeVal,
 U8                     CauseType
 )

--- a/TestCntlrApp/src/enbApp/nb_dam_ifm_app.c
+++ b/TestCntlrApp/src/enbApp/nb_dam_ifm_app.c
@@ -32,7 +32,7 @@
 
 EXTERN Void nbIfmDamNbSendLmAlarm(U16, U16, U16);
 EXTERN Void  nbDamTnlCreatReq(NbDamTnlInfo*);
-EXTERN NbDamUeCb* nbDamGetUe(U8 ueId);
+EXTERN NbDamUeCb* nbDamGetUe(U32 ueId);
 
 /** @brief This function is used to configure the Data Application Module.
  *
@@ -197,7 +197,7 @@ PUBLIC S16 nbIfmDamNbTnlCreatReq
 
 PUBLIC S16 nbIfmDamHandleUeCntxtRelReq
 (
- U16 ueId,
+ U32 ueId,
  U8 causeVal,
  U8 CauseType
 )
@@ -278,7 +278,7 @@ PUBLIC S16 nbIfmDamNbTnlDelCfm
 )
 {
    Pst *pst;
-   U8 ueId  = (lclTeid & 0x00ffff00) >> 8;
+   U32 ueId  = (lclTeid & 0x00ffff00) >> 8;
 
    TRC2(nbIfmDamNbTnlDelCfm);
    if(status == LCM_PRIM_OK)
@@ -325,7 +325,7 @@ PUBLIC S16 nbIfmDamNbTnlDelCfm
  */
 PUBLIC Void nbIfmDamNbCtxtRel
 (
-U8                     ueId,
+U32                     ueId,
 U8                     causeVal,
 U8                     CauseType
 )

--- a/TestCntlrApp/src/enbApp/nb_dam_ifm_app.h
+++ b/TestCntlrApp/src/enbApp/nb_dam_ifm_app.h
@@ -39,8 +39,8 @@ EXTERN S16 nbIfmDamNbCfgCfm(LnbMngmt*, CmStatus*);
 EXTERN S16 nbIfmDamNbTnlCreatCfm(U8, U32);
 EXTERN S16 nbIfmDamNbTnlDelCfm(U8, U32);
 EXTERN S16 nbIfmDamNbTnlCreatReq(NbDamTnlInfo*);
-EXTERN Void nbIfmDamNbCtxtRel(U8, U8, U8);
-EXTERN S16 nbIfmDamHandleUeCntxtRelReq(U16, U8, U8);
+EXTERN Void nbIfmDamNbCtxtRel(U32, U8, U8);
+EXTERN S16 nbIfmDamHandleUeCntxtRelReq(U32, U8, U8);
 /* Functions called from dam file - end*/
 #ifdef __cplusplus
 }

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.c
@@ -190,7 +190,7 @@ PUBLIC S16 nbIfmDamTnlCreatReq
 
 PUBLIC S16 nbIfmDamUeRelReq
 (
- U16 ueId,
+ U32 ueId,
  U8 cause
 )
 {
@@ -215,7 +215,7 @@ PUBLIC S16 nbIfmDamUeRelReq
  */
 PUBLIC S16 nbIfmDamUeDelReq
 (
- U8 ueId
+ U32 ueId
 )
 {
    Pst *pst;
@@ -249,7 +249,7 @@ PUBLIC S16 nbIfmDamErabDelReq
 
 PUBLIC Void nbIfmDamNbUeDelReq
 (
- U8 ueId
+ U32 ueId
 )
 {
    nbDamUeDelReq(ueId);

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam.h
@@ -237,11 +237,11 @@ EXTERN S16 nbIfmDamCfgCfm(LnbMngmt*, CmStatus*);
 EXTERN S16 nbIfmDamTnlCreatReq(NbDamTnlInfo*);
 EXTERN Void wrIfmDamWrCntrlReq(LnbMngmt *cfg);
 EXTERN Void wrIfmDamWrCfgReq(LnbMngmt *cfg);
-EXTERN S16 nbIfmDamUeDelReq(U8);
+EXTERN S16 nbIfmDamUeDelReq(U32);
 EXTERN S16 nbIfmDamErabDelReq(Void *);
 EXTERN S16 nbIfmDamUeDelCfm(U32, U16, U16);
-EXTERN Void nbIfmDamNbUeDelReq(U8);
-EXTERN S16 nbIfmDamUeRelReq(U16, U8);
+EXTERN Void nbIfmDamNbUeDelReq(U32);
+EXTERN S16 nbIfmDamUeRelReq(U32, U8);
 
 EXTERN Void  wrIfmDamSendAlarmInd(U16 category,U16 event,U16 cause);
 EXTERN S16 wrIfmDamCfgReq(LnbMngmt *cfg);
@@ -278,7 +278,7 @@ EXTERN S16 wrIfmDamChngTnlState(NbDamTnlStInfo *tnlStInfo);
 EXTERN S16 wrDamTnlStChngReq(NbDamTnlStInfo *tnlStInfo);
 
 /* Primitive to start end marker timer                                    */
-EXTERN S16 wrDamStartEndMrkrTmr(U16 cellId, U16 ueId);
+EXTERN S16 wrDamStartEndMrkrTmr(U16 cellId, U32 ueId);
 
 EXTERN S16 wrUmmPrcEgtpErrInd(U32 lclTeid, U32 numDrbs, U16 crnti);
 
@@ -305,10 +305,10 @@ EXTERN S16 wrIfmDamReestabReq(U32 transId, U16 cellId, U16 ocrnti, U16 ncrnti);
 /* RLC_DL_MAX_RETX fix */
 EXTERN S16 wrIfmDamWrReCfgReq(U32 transId,U16 cellId,U16 crnti);
 EXTERN S16 wrIfmDamReCfgReq(U32 transId,U16 cellId,U16 crnti);
-EXTERN S16 wrIfmDamStopUeTmr(U16 cellId,U16 ueId);
-EXTERN S16 wrDamStopUeTmr (U16 cellId,U16 ueId);
+EXTERN S16 wrIfmDamStopUeTmr(U16 cellId,U32 ueId);
+EXTERN S16 wrDamStopUeTmr (U16 cellId,U32 ueId);
 EXTERN S16 wrIfmDamStartInactivityTimer(U16 cellId,U16 crnti);
-EXTERN S16 wrIfmDamSetDataRcvdFlag(U16 cellId, U16 ueId);/*ccpu00138576*/
+EXTERN S16 wrIfmDamSetDataRcvdFlag(U16 cellId, U32 ueId);/*ccpu00138576*/
 
 
 #ifdef __cplusplus

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
@@ -674,7 +674,7 @@ Buffer *mBuf;
 * Function:cmPkUeDelReq 
 * 
 * @param[in]   Pst *  pst
-* @param[in]   U32 ueId 
+* @param[in]   U32 ueId
 * @return   S16
 *  -# ROK
 **/
@@ -866,7 +866,7 @@ Buffer *mBuf;
 * Function: cmPkDamSendCtxtRel 
 *
 * @param[in] Pst      *pst
-* @param[in] U32       ueId 
+* @param[in] U32      ueId
 * @param[in] U8       causeVal
 * @param[in] U8       causeTyp 
 * @return   S16

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
@@ -538,7 +538,7 @@ Buffer *mBuf;
 PUBLIC S16 cmPkUeCntxtRelReq
 (
  Pst *pst,
- U16 ueId,
+ U32 ueId,
  U8 cause
 )
 {
@@ -550,7 +550,7 @@ PUBLIC S16 cmPkUeCntxtRelReq
 
       RETVALUE(RFAILED);
    }
-   CMCHKPKLOG(SPkU16, ueId, mBuf, 0, pst);
+   CMCHKPKLOG(SPkU32, ueId, mBuf, 0, pst);
    CMCHKPKLOG(SPkU8, cause, mBuf, 0, pst);
  
    pst->event = (Event)EVTDAMUECNTXTRELREQ;
@@ -563,11 +563,11 @@ Pst *pst,
 Buffer *mBuf
 )
 {
-   U16 ueId = 0;
+   U32 ueId = 0;
    U8 causeVal = 0;
    U8 causeType = 0;
 
-   CMCHKUNPKLOG(SUnpkU16, &ueId, mBuf, 0, pst);
+   CMCHKUNPKLOG(SUnpkU32, &ueId, mBuf, 0, pst);
    CMCHKUNPKLOG(SUnpkU8, &causeVal, mBuf, 0, pst);
    CMCHKUNPKLOG(SUnpkU8, &causeType, mBuf, 0, pst);
 
@@ -674,7 +674,7 @@ Buffer *mBuf;
 * Function:cmPkUeDelReq 
 * 
 * @param[in]   Pst *  pst
-* @param[in]   U8 ueId 
+* @param[in]   U32 ueId 
 * @return   S16
 *  -# ROK
 **/
@@ -682,12 +682,12 @@ Buffer *mBuf;
 PUBLIC S16 cmPkUeDelReq 
 (
 Pst *pst,
-U8 ueId
+U32 ueId
 )
 #else
 PUBLIC S16 cmPkUeDelReq(pst, ueId)
 Pst * pst;
-U8 ueId;
+U32 ueId;
 #endif
 {
    Buffer *mBuf = NULLP;
@@ -699,7 +699,7 @@ U8 ueId;
       NB_LOG_ERROR(&nbCb,"Memory allocation failed.");
       RETVALUE(RFAILED);
    }
-   CMCHKPKLOG(SPkU8, ueId, mBuf, EDAM002, pst);
+   CMCHKPKLOG(SPkU32, ueId, mBuf, EDAM002, pst);
 
    
    pst->event = (Event)EVTDAMUEDELTREQ;
@@ -733,9 +733,9 @@ Pst *pst;
 Buffer *mBuf;
 #endif
 {
-   U8 ueId  = 0;
+   U32 ueId  = 0;
 
-   CMCHKUNPKLOG(SUnpkU8, (&ueId), mBuf, EDAM007, pst);
+   CMCHKUNPKLOG(SUnpkU32, (&ueId), mBuf, EDAM007, pst);
 
    NB_DAM_FREE_BUFFER(pst->region, mBuf);
    nbIfmDamNbUeDelReq(ueId);
@@ -784,7 +784,7 @@ PUBLIC Void cmUnPkErabDelReq
 * Function:cmPkUeDelCfm 
 * 
 * @param[in]   Pst *  pst
-* @param[in]   U16 ueId
+* @param[in]   U32 ueId
 * @return   S16
 *  -# ROK
 **/
@@ -792,12 +792,12 @@ PUBLIC Void cmUnPkErabDelReq
 PUBLIC S16 cmPkUeDelCfm 
 (
  Pst *pst,
- U8 ueId
+ U32 ueId
 )
 #else
 PUBLIC S16 cmPkUeDelCfm(pst, ueId)
 Pst * pst;
-U8 ueId;
+U32 ueId;
 #endif
 {
    Buffer *mBuf = NULLP;
@@ -811,7 +811,7 @@ U8 ueId;
       RETVALUE(RFAILED);
    }
    
-   CMCHKPKLOG(SPkU8, ueId, mBuf, EDAM002, pst);
+   CMCHKPKLOG(SPkU32, ueId, mBuf, EDAM002, pst);
    
    pst->event = (Event)EVTDAMUEDELTCFM;
    RETVALUE(SPstTsk(pst, mBuf));
@@ -845,11 +845,11 @@ Pst *pst;
 Buffer *mBuf;
 #endif
 {
-    U8 ueId = 0;
+    U32 ueId = 0;
  
     TRC3(cmUnPkUeDelCfm)
 
-    CMCHKUNPKLOG(SUnpkU8,(&ueId), mBuf, EDAM001, pst);
+    CMCHKUNPKLOG(SUnpkU32,(&ueId), mBuf, EDAM001, pst);
  
     NB_DAM_FREE_BUFFER (pst->region, mBuf);
  
@@ -866,7 +866,7 @@ Buffer *mBuf;
 * Function: cmPkDamSendCtxtRel 
 *
 * @param[in] Pst      *pst
-* @param[in] U8       ueId 
+* @param[in] U32       ueId 
 * @param[in] U8       causeVal
 * @param[in] U8       causeTyp 
 * @return   S16
@@ -875,7 +875,7 @@ Buffer *mBuf;
 PUBLIC S16 cmPkDamSendCtxtRel 
 (
 Pst *pst,
-U8  ueId,
+U32  ueId,
 U8  causeVal,
 U8  causeTyp
 )
@@ -890,7 +890,7 @@ U8  causeTyp
       RETVALUE(RFAILED);
    }
 
-   CMCHKPKLOG(SPkU8, ueId, mBuf,0, pst);
+   CMCHKPKLOG(SPkU32, ueId, mBuf,0, pst);
    CMCHKPKLOG(SPkU8, causeVal, mBuf,0, pst);
    CMCHKPKLOG(SPkU8, causeTyp, mBuf,0, pst);
 
@@ -926,7 +926,7 @@ Pst *pst;
 Buffer *mBuf;
 #endif
 {
-   U8  ueId;
+   U32  ueId;
    U8  causeVal;
    U8  causeTyp;
    NbUeMsgCause relCause;
@@ -935,7 +935,7 @@ Buffer *mBuf;
 
    CMCHKUNPKLOG(SUnpkU8,&causeVal, mBuf,0, pst);
    CMCHKUNPKLOG(SUnpkU8,&causeTyp, mBuf,0, pst);
-   CMCHKUNPKLOG(SUnpkU8,(&ueId), mBuf,0, pst);
+   CMCHKUNPKLOG(SUnpkU32,(&ueId), mBuf,0, pst);
    NB_DAM_FREE_BUFFER(pst->region, mBuf);
    
    relCause.causeTyp = causeTyp;

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.h
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.h
@@ -117,5 +117,5 @@ EXTERN Void cmUnpkDamCntrlReq(Pst *pst,Buffer *mBuf);
 EXTERN Void cmUnpkDamCfgCfm(Pst *pst,Buffer *mBuf);
 EXTERN Void cmUnpkDamCntrlCfm(Pst *pst,Buffer *mBuf);
 EXTERN Void cmUnPkUeDelCfm(Pst *pst,Buffer *mBuf);
-EXTERN S16 cmPkUeDelCfm(Pst*, U8);
+EXTERN S16 cmPkUeDelCfm(Pst*, U32);
 #endif /* __NBIFMDAMUTL_H__ */

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.x
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.x
@@ -64,12 +64,12 @@ EXTERN S16 cmUnPkUeCntxtRelReq(Pst*, Buffer*);
 
 EXTERN S16 cmPkTnlCreatReq(Pst*, NbDamTnlInfo*);
 
-EXTERN S16 cmPkUeDelReq(Pst*, U8);
+EXTERN S16 cmPkUeDelReq(Pst*, U32);
 
 EXTERN S16 cmPkErabDelReq(Pst*, Void*);
 
-EXTERN S16 cmPkDamSendCtxtRel (Pst*, U8, U8, U8);
+EXTERN S16 cmPkDamSendCtxtRel (Pst*, U32, U8, U8);
 
-EXTERN S16 cmPkUeCntxtRelReq(Pst*, U16, U8);
+EXTERN S16 cmPkUeCntxtRelReq(Pst*, U32, U8);
 /* Pack Function Prototype */
 #endif

--- a/TestCntlrApp/src/enbApp/nb_ifm_egtp.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_egtp.c
@@ -508,7 +508,7 @@ EgtUEvnt                     *eguMsg
 
    TRC2(NbIfmEgtpEguErrInd);
 #if 0
-   U32  ueIdx;
+   U32 ueIdx;
    U8  tnlType;
    U32 lclTeid;
    lclTeid = eguMsg->u.errInd.localTeid;

--- a/TestCntlrApp/src/enbApp/nb_ifm_egtp.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_egtp.c
@@ -508,7 +508,7 @@ EgtUEvnt                     *eguMsg
 
    TRC2(NbIfmEgtpEguErrInd);
 #if 0
-   U8  ueIdx;
+   U32  ueIdx;
    U8  tnlType;
    U32 lclTeid;
    lclTeid = eguMsg->u.errInd.localTeid;

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -31,14 +31,14 @@
 #include "nbt.x"
 
 EXTERN U8 uesLocalRel;
-EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U8 ueId);
+EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId);
 PUBLIC S16 nbCtxtRelSndRlsCmpl(NbUeCb*);
 PUBLIC S16 nbProcessDlNasMsg(NbUeCb*, S1apPdu*, U8);
 PUBLIC S16 nbGetTai(NbTai*);
 #ifdef MULTI_ENB_SUPPORT
-PUBLIC U32  nbGetUeLclTeid(U8, U32, U32);
+PUBLIC U32  nbGetUeLclTeid(U32, U32, U32);
 #else
-PUBLIC U32  nbGetUeLclTeid(U8, U32);
+PUBLIC U32  nbGetUeLclTeid(U32, U32);
 #endif
 PUBLIC S16 nbGetErabInfoFrmIntCnxt(NbUeCb*, SztE_RABToBeSetupLstCtxtSUReq*,
       NbErabLst**);
@@ -72,8 +72,8 @@ PUBLIC S16  NbBuildAndSndErrIndMsg(NbErrIndMsg *s1ErrInd);
 PUBLIC S16 sendNonDelFlag(NbUeCb *ueCb, SztNAS_PDU *pdu, NbUeMsgCause *cause);
 PUBLIC S16 sendInitCtxtSetupFailRsp(NbUeCb *ueCb, NbUeMsgCause *cause);
 PRIVATE S16 nbSendUeCtxtRelReqAsICSRsp(NbUeCb *ueCb);
-PRIVATE S16 nbStartDelayTimerForICSRsp(U8 ueId,NbErabLst *erabInfo);
-PRIVATE S16 nbStartDelayTimerForUeCtxRel(U8 ueId);
+PRIVATE S16 nbStartDelayTimerForICSRsp(U32 ueId,NbErabLst *erabInfo);
+PRIVATE S16 nbStartDelayTimerForUeCtxRel(U32 ueId);
 PUBLIC S16 nbHandleDelayTimerForUeCtxRelComplExpiry(NbDelayUeCtxtRelCmpCb *ueCtxtRelCmpCb);
 PUBLIC S16 nbPrcPathSwReqAck(NbUeCb *ueCb,S1apPdu *pdu);
 EXTERN S16 nbUiSendPathSwReqAckToUser(NbPathSwReqAck *nbpathSwReqAck);
@@ -293,7 +293,7 @@ PUBLIC S16 nbBuildAndSendErabRelRsp
 
 
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&enbUeS1apId,
-				   sizeof(U8),0,(PTR *)&ueCb)))
+				   sizeof(U32),0,(PTR *)&ueCb)))
    {
 	   NB_LOG_ERROR(&nbCb, "Failed to Find UeCb");
 	   RETVALUE(RFAILED);
@@ -1364,7 +1364,7 @@ PUBLIC S16 nbProcErabRelCmd(S1apPdu *s1apErabRlsCmd)
   /*for(cnt = 0; cnt < nbCb.crntUeIdx; cnt++)
   {
   }*/
-  cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(enbUeS1apId), sizeof(U8), 0,
+  cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(enbUeS1apId), sizeof(U32), 0,
                  (PTR *)(&ueCb));
   for (cnt = 0; cnt < numOfErabIdsRlsd; cnt++) {
     U32 bearerId = erabRelCmd.erabIdLst[cnt];
@@ -1576,7 +1576,7 @@ PUBLIC S16 nbUpdateUePagInfo
    U16                    memberIdx = 0;
    TknBStr32              *ueIdxBitStr = NULLP;
    U16                    numCompPagMsg = 0;
-   U16                    ueId = 0;
+   U32                    ueId = 0;
    U8                     idx1, idx2;
    U16                    memberId;
 
@@ -2456,7 +2456,7 @@ PUBLIC S16 nbPrcS1apRelInd
  SztRelInd   *relInd
 )
 {
-   U8 ueIdx = 0;
+   U32 ueIdx = 0;
    S16 retVal = ROK;
    U8 msgType = NB_S1_REL_IND;
    NbUeCb *ueCb = NULLP;
@@ -2466,7 +2466,7 @@ PUBLIC S16 nbPrcS1apRelInd
    ueCb  = nbCb.ueCbLst[ueIdx];
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueIdx),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       RETVALUE(RFAILED);
    }
@@ -2481,7 +2481,7 @@ PUBLIC S16 nbPrcS1apConCfm
  SztConCfm   *conCfm
 )
 {
-   U8 ueIdx = 0;
+   U32 ueIdx = 0;
    S16 retVal = ROK;
    U8 msgType = NB_S1_CON_CFM;
    NbUeCb *ueCb = NULLP;
@@ -2491,7 +2491,7 @@ PUBLIC S16 nbPrcS1apConCfm
    ueCb  = nbCb.ueCbLst[ueIdx];
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueIdx),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       RETVALUE(RFAILED);
    }
@@ -2506,7 +2506,7 @@ PUBLIC S16 nbPrcS1DatInd
  SztDatEvntInd   *s1DatInd
 )
 {
-   U8 ueIdx = 0;
+   U32 ueIdx = 0;
    S16 retVal = ROK;
    U8 msgType = NB_S1_DAT_IND;
    NbUeCb *ueCb = NULLP;
@@ -2516,7 +2516,7 @@ PUBLIC S16 nbPrcS1DatInd
    ueCb =  nbCb.ueCbLst[ueIdx];
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueIdx),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       RETVALUE(RFAILED);
    }
@@ -3531,9 +3531,9 @@ PUBLIC S16 nbGetTai
 
 
 #ifdef MULTI_ENB_SUPPORT
-PUBLIC U32  nbGetUeLclTeid(U8 ueId, U32 rabId, U32 enbId)
+PUBLIC U32  nbGetUeLclTeid(U32 ueId, U32 rabId, U32 enbId)
 #else
-PUBLIC U32  nbGetUeLclTeid(U8 ueId, U32 rabId)
+PUBLIC U32  nbGetUeLclTeid(U32 ueId, U32 rabId)
 #endif
 {
    U32 lclTeId = 0;
@@ -3725,8 +3725,8 @@ PRIVATE S16 nbFillErrIndMsg(NbErrIndMsg *s1ErrInd,S1apPdu **errIndPdu)
 
    U16 numComp = 0;
    S16 ret = 0;
-   U8 ueId = 0;
-   U8 idx = 0;
+   U32 ueId = 0;
+   U32 idx = 0;
    NbUeCb *ueCb = NULLP;
    NbS1ConCb *s1apConCb = NULLP;
 
@@ -3756,7 +3756,7 @@ PRIVATE S16 nbFillErrIndMsg(NbErrIndMsg *s1ErrInd,S1apPdu **errIndPdu)
    {
       ueId = s1ErrInd->ue_Id;
       if(ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-              sizeof(U8), 0, (PTR *)&ueCb)))
+              sizeof(U32), 0, (PTR *)&ueCb)))
       {
          NB_LOG_ERROR(&nbCb, "ueCb not found for UeId %d", ueId);
          RETVALUE(RFAILED);
@@ -3884,7 +3884,7 @@ PRIVATE S16 nbFillErrIndMsg(NbErrIndMsg *s1ErrInd,S1apPdu **errIndPdu)
    }
    RETVALUE(ROK);
 }
-PRIVATE S16 nbStartDelayTimerForUeCtxRel(U8 ueId)
+PRIVATE S16 nbStartDelayTimerForUeCtxRel(U32 ueId)
 {
    S16 retVal = RFAILED;
    NbDelayUeCtxtRelCmpCb *ueCtxtRelCmp = NULLP;
@@ -3894,7 +3894,7 @@ PRIVATE S16 nbStartDelayTimerForUeCtxRel(U8 ueId)
    retVal = nbStartTmr((PTR)ueCtxtRelCmp, NB_TMR_DELAY_UE_CTX_REL_COMP, nbCb.delayUeCtxtRelCmp[ueId - 1].tmrVal);
    RETVALUE(retVal);
 }
-PRIVATE S16 nbStartDelayTimerForICSRsp(U8 ueId,NbErabLst *erabInfo)
+PRIVATE S16 nbStartDelayTimerForICSRsp(U32 ueId,NbErabLst *erabInfo)
 {
   S16 retVal = RFAILED;
   NbDelayICSRspCb *icsRspCb = NULLP;
@@ -3915,7 +3915,7 @@ PUBLIC S16 nbHandleDelayTimerForICSExpiry(NbDelayICSRspCb *icsRspCb)
    NbErabLst *erabInfo = NULLP;
 
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(icsRspCb->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb, "Failed to Find UeCb");
       RETVALUE(RFAILED);
@@ -3975,7 +3975,7 @@ PUBLIC S16 nbHandleDelayTimerForUeCtxRelComplExpiry(NbDelayUeCtxtRelCmpCb *ueCtx
    S16 retVal = RFAILED;
    NbUeCb *ueCb = NULLP;
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueCtxtRelCmp->ueId),
-				   sizeof(U8),0,(PTR *)&ueCb)))
+				   sizeof(U32),0,(PTR *)&ueCb)))
    {
 	   NB_LOG_ERROR(&nbCb, "Failed to Find UeCb");
 	   RETVALUE(RFAILED);

--- a/TestCntlrApp/src/enbApp/nb_traffic_handler.c
+++ b/TestCntlrApp/src/enbApp/nb_traffic_handler.c
@@ -77,7 +77,7 @@ typedef struct nbAppDataRoutCb
 
 typedef struct _ueDataCb
 {
-   U8 ueId;
+   U32 ueId;
    NbAppDataRouteCb   *ipInfo[11];
    U8 noOfIpsAssigned;
 }UeDataCb;
@@ -769,14 +769,14 @@ PRIVATE S16 nbAppSendArpReqPkt
 
 PUBLIC S16 nbAppCfgrPdnAssignedAddr
 (
- U8 ueId,
+ U32 ueId,
  U32 pdnAsgndAddr
 )
 {
    S16 ret;
    UeDataCb *ueDatCb = NULLP;
    U8 ipAddr[NB_APP_MAX_IP_ADDR_LEN];
-   U8 idx = 0;
+   U32 idx = 0;
    U8 idx1 = 0;
    NbAppDataRouteCb *ipInfo = NULLP;
 
@@ -867,10 +867,10 @@ PUBLIC S16 nbAppCfgrPdnAssignedAddr
 
 PUBLIC Void nbRelCntxtInTrafficHandler
 (
- U8 ueId
+ U32 ueId
 )
 {
-   U8 idx = 0;
+   U32 idx = 0;
    U8 idx1;
    UeDataCb *ueDatCb = NULLP;
 

--- a/TestCntlrApp/src/enbApp/nb_traffic_handler.x
+++ b/TestCntlrApp/src/enbApp/nb_traffic_handler.x
@@ -8,8 +8,8 @@
 
 EXTERN S16 nbAppRouteInit(U32, S8*);
 EXTERN Void nbAppHndlIPPkt(CONSTANT U8*, U32);
-EXTERN S16 nbAppCfgrPdnAssignedAddr(U8, U32);
+EXTERN S16 nbAppCfgrPdnAssignedAddr(U32, U32);
 EXTERN Void *nbAppPktReceiver(Void*);
 EXTERN U16 nbAppCalcIPChecksum(U8*, U32);
 EXTERN S16 nbAppFrwdIpPkt(U8*, U32);
-EXTERN Void nbRelCntxtInTrafficHandler(U8);
+EXTERN Void nbRelCntxtInTrafficHandler(U32);

--- a/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_ue_msg_hndlr.c
@@ -65,7 +65,7 @@ PUBLIC S16 NbHandleInitialUeMsg
    U8 offset  = 0;
    S16 ret = 0;
    if ( ROK == (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(initialUeMsg->ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
    } else {
    NB_ALLOC(&ueCb, sizeof(NbUeCb))
@@ -173,7 +173,7 @@ PUBLIC S16 NbHandleInitialUeMsg
 #endif
 
    if (ROK != cmHashListInsert(&(nbCb.ueCbLst),(PTR)ueCb,
-                     (U8 *) &ueCb->ueId,sizeof(U8)))
+                     (U8 *) &ueCb->ueId,sizeof(U32)))
    {
       NB_FREE(ueCb, sizeof(NbUeCb))
       NB_FREE(s1apConCb, sizeof(NbS1ConCb));
@@ -448,7 +448,7 @@ PUBLIC S16 nbSendErabsInfo(NbUeCb *ueCb, NbErabLst *erabInfo,
 
 PUBLIC S16 nbSendS1RelIndToUeApp
 (
- U8 ueId
+ U32 ueId
 )
 {
    S16 ret = ROK;
@@ -497,7 +497,7 @@ PUBLIC S16 nbS1apFillEutranCgi
 PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
 {
   U32 ueIpAddr = 0;
-  U8 ueId;
+  U32 ueId;
   U8 bearerId;
 
   ueId = rsp->ueId;
@@ -512,7 +512,7 @@ PUBLIC S16 NbHandleUeIpInfoRsp(NbuUeIpInfoRsp *rsp)
   RETVALUE(nbCreateUeTunnReq(ueId, ueIpAddr, bearerId, rsp));
 }
 
-PUBLIC Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId)
+PUBLIC Void nbHandleUeIpInfoReq(U32 ueId,U8 bearerId)
 {
    S16 ret             = ROK;
    NbuUeIpInfoReq *msg = NULLP;
@@ -529,7 +529,7 @@ PUBLIC Void nbHandleUeIpInfoReq(U8 ueId,U8 bearerId)
    }
 }
 
-PUBLIC S16 nbNotifyPlmnInfo(U8 ueId, NbPlmnId plmnId )
+PUBLIC S16 nbNotifyPlmnInfo(U32 ueId, NbPlmnId plmnId )
 {
   S16 ret = ROK;
   U8      pLMNId[3];

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -46,7 +46,7 @@ EXTERN S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail*);
 EXTERN S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup*);
 EXTERN S16 NbEnbDelayInitCtxtSetupRsp(NbDelayICSRsp*);
 EXTERN S16 NbEnbUeCtxtRelForInitCtxtSetup(NbSendUeCtxtRelForICSRsp*);
-EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U8 ueId);
+EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId);
 EXTERN S16 NbEnbDelayUeCtxtRelCmp(NbDelayUeCtxtRelCmp*);
 EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 
@@ -290,7 +290,7 @@ PUBLIC S16 NbUiNbuHdlUlNasMsg
  NbuUlNasMsg *msg
 )
 {
-   U8 ueId = 0;
+   U32 ueId = 0;
    NbUeCb *ueCb = NULLP;
    NbS1ConCb *s1apConCb = NULLP;
    SztDatEvntReq s1UlInfoMsg = {0};
@@ -316,7 +316,7 @@ PUBLIC S16 NbUiNbuHdlUlNasMsg
    }
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb, "ueCb not found for UeId %d", ueId);
       NB_FREE(msg->nasPdu.val, msg->nasPdu.len);
@@ -384,7 +384,7 @@ PUBLIC S16 NbUiNbuHdlUeRadioCapMsg
  NbuUlRrcMsg *msg
 )
 {
-   U8 ueId;
+   U32 ueId;
    NbUeCb    *ueCb = NULLP;
    NbS1ConCb * s1apConCb = NULLP;
    SztDatEvntReq      s1UlInfoMsg;
@@ -412,7 +412,7 @@ PUBLIC S16 NbUiNbuHdlUeRadioCapMsg
    }
 #endif
    if ( ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueId),
-      sizeof(U8),0,(PTR *)&ueCb)))
+      sizeof(U32),0,(PTR *)&ueCb)))
    {
       NB_LOG_ERROR(&nbCb,"NbUiNbuHdlUeRadioCapMsg: ueCb not found");
       NB_FREE(msg->rrcPdu.val,msg->rrcPdu.len);
@@ -493,7 +493,7 @@ PUBLIC S16 nbUiBuildAndSendDlNasMsg
 #if 0
 PUBLIC S16 nbUiBuildAndSendNasNonDlvryIndToTfw
 (
- U8 ueId
+ U32 ueId
 )
 {
    NbtMsg * msg = NULLP;
@@ -554,7 +554,7 @@ PUBLIC S16 nbUiBuildAndSendPagingMsg
    RETVALUE(ROK);
 } /* nbUiBuildAndSendPagingMsg */
 
-PUBLIC Void nbUiNbuHandleUeInactivity(U8 ueId)
+PUBLIC Void nbUiNbuHandleUeInactivity(U32 ueId)
 {
    NbuUeInActvInd *msg;
    NB_ALLOC(&msg, sizeof(NbuUeInActvInd));
@@ -764,7 +764,7 @@ PUBLIC S16 nbUiSendResetAckToUser(NbResetAckldg *resetAck)
    RETVALUE(ROK);
 } /* nbUiSendResetAckToUser */
 
-PUBLIC S16 nbUiSendUeCtxRelIndToUser(U8 ueId)
+PUBLIC S16 nbUiSendUeCtxRelIndToUser(U32 ueId)
 {
    NbtResponse *rsp = NULLP;
    Pst pst;
@@ -794,7 +794,7 @@ PUBLIC S16 nbUiSendUeCtxRelIndToUser(U8 ueId)
    RETVALUE(ROK);
 } /* nbUiSendUeCtxRelIndToUser */
 
-PUBLIC S16 nbUiSendIntCtxtSetupIndToUser(U8 ueId, U8 status)
+PUBLIC S16 nbUiSendIntCtxtSetupIndToUser(U32 ueId, U8 status)
 {
    NbtResponse *rsp = NULLP;
    Pst pst;
@@ -825,7 +825,7 @@ PUBLIC S16 nbUiSendIntCtxtSetupIndToUser(U8 ueId, U8 status)
    RETVALUE(ROK);
 } /* nbUiSendUeCtxRelIndToUser */
 
-PUBLIC S16 nbUiSendIntCtxtSetupDrpdIndToUser(U8 ueId)
+PUBLIC S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId)
 {
    NbtResponse *rsp = NULLP;
    Pst pst;

--- a/TestCntlrApp/src/enbApp/nb_utils.c
+++ b/TestCntlrApp/src/enbApp/nb_utils.c
@@ -853,7 +853,7 @@ PUBLIC S16 nbGetUeIdFromS1apId
 (
  U32 enbUeS1apId,
  U32 mmeUeS1apId,
- U8 *ueId
+ U32 *ueId
 )
 {
    U8 cnt = 0;

--- a/TestCntlrApp/src/enbApp/nb_utils.h
+++ b/TestCntlrApp/src/enbApp/nb_utils.h
@@ -47,7 +47,7 @@ EXTERN S16 nbGetUeIdFromS1apId
 (
  U32 enbUeS1apId,
  U32 mmeUeS1apId,
- U8 *ueId
+ U32 *ueId
 );
 
 EXTERN S16 nbFillTknStrOSXL(

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -274,7 +274,7 @@ typedef struct _nbCriticalityDiag
 typedef struct _nbErrIndMsg
 {
    U8          isUeAssoc;
-   U32          ue_Id;
+   U32         ue_Id;
    U8          causePres;
    FailCause   cause;
    NbCriticalityDiag criticalityDiag;

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -199,7 +199,7 @@ typedef struct _nbRelCause
 }NbRelCause;
 typedef struct _nbUeCntxtRelReq
 {
-   U16 ueId;
+   U32 ueId;
    NbRelCause cause;
 }NbUeCntxtRelReq;
 
@@ -218,7 +218,7 @@ typedef struct _nbCompleteReset
 typedef struct _mnPartialReset
 {
    U16 numOfConn;
-   U8 *ueIdLst;
+   U32 *ueIdLst;
 }NbPartialReset;
 
 typedef struct _nbCause
@@ -241,8 +241,8 @@ typedef struct _resetRequest
 typedef struct _nbResetRequest
 {
    U8 status;
-   U16 numOfUes;
-   U8 *ueIdLst;
+   U32 numOfUes;
+   U32 *ueIdLst;
 }NbResetAckldg;
 
 typedef struct _nbCriticalityDiag_IE_Item
@@ -274,7 +274,7 @@ typedef struct _nbCriticalityDiag
 typedef struct _nbErrIndMsg
 {
    U8          isUeAssoc;
-   U8          ue_Id;
+   U32          ue_Id;
    U8          causePres;
    FailCause   cause;
    NbCriticalityDiag criticalityDiag;
@@ -287,7 +287,7 @@ typedef struct _nbSctpAbortReqMsg
 
 typedef struct _nbErabRelInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 numOfErabIds;
    U8 *erabIdLst;
 }NbErabRelInd;
@@ -296,7 +296,7 @@ typedef NbErabRelInd NbErabRelReq;
 
 typedef struct _nbErabRelCmd
 {
-   U8 ueId;
+   U32 ueId;
    U32 mmeUeS1apId;
    U32 enbUeS1apId;
    U8 numOfErabIds;
@@ -306,7 +306,7 @@ typedef struct _nbErabRelCmd
 
 typedef struct _nbErabRelRsp
 {
-   U8 ueId;
+   U32 ueId;
    U32 mmeUeS1apId;
    U32 enbUeS1apId;
    U8 numOfErabIds;
@@ -316,27 +316,27 @@ typedef struct _nbErabRelRsp
 
 typedef struct _nbUeCtxRelInd
 {
-   U8 ueId;
+   U32 ueId;
 }NbUeCtxRelInd;
 typedef struct _nbIntCtxtSetUpInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 status;
 }NbIntCtxtSetUpInd;
 typedef struct _nbIntCtxtSetUpDrpdInd
 {
-   U8 ueId;
+   U32 ueId;
 }NbIntCtxtSetUpDrpdInd;
 typedef struct _nbNasNonDel
 {
-   U8 ueId;
+   U32 ueId;
    Bool flag;
    U32 causeType;
    U32 causeVal;
 }NbNasNonDel;
 typedef struct _nbInitCtxtSetupFail
 {
-   U8 ueId;
+   U32 ueId;
    Bool initCtxtSetupFailInd;
    U32 causeType;
    U32 causeVal;
@@ -344,34 +344,34 @@ typedef struct _nbInitCtxtSetupFail
 
 typedef struct _nbDropInitCtxtSetup
 {
-   U8 ueId;
+   U32 ueId;
    Bool isDropICSEnable;
    U32 tmrVal;
 }NbDropInitCtxtSetup;
 typedef struct _nbDelayICSRsp
 {
-   U8 ueId;
+   U32 ueId;
    Bool isDelayICSRsp;
    U32 tmrVal;
 }NbDelayICSRsp;
 
 typedef struct _nbDelayUeCtxtRelCmp
 {
-   U8 ueId;
+   U32 ueId;
    Bool isDelayUeCtxtRelCmp;
    U32 tmrVal;
 }NbDelayUeCtxtRelCmp;
 
 typedef struct _nbSendUeCtxtRelForICSRsp
 {
-   U8 ueId;
+   U32 ueId;
    U32 causeType;
    U32 causeVal;
    Bool sndICSRspUeCtxtRel;
 }NbSendUeCtxtRelForICSRsp;
 typedef struct _nbNasNonDelRsp
 {
-   U8 ueId;
+   U32 ueId;
 }NbNasNonDelRsp;
 typedef struct _nbmultiEnbCfgParam
 {
@@ -390,12 +390,12 @@ typedef struct _nbMultiEnbConfigReq
 
 typedef struct _nbX2HOTriggerReq
 {
-   U8 ueId;
+   U32 ueId;
 }NbX2HOTriggerReq;
 
 typedef struct _nbPathSwReqAck
 {
-   U8 ueId;
+   U32 ueId;
    U32 mmeUeS1apId;
    U32 enbUeS1apId;
    U32 ncc;
@@ -404,13 +404,13 @@ typedef struct _nbPathSwReqAck
 
 typedef struct _nbTunDelReq
 {
-   U8 ueId;
+   U32 ueId;
    U32 bearerId;
 }NbTunDelReq;
 
 typedef struct _nbEnbConfigTrnsf
 {
-   U8 ueId;
+   U32 ueId;
 }NbEnbConfigTrnsf;
 
 typedef struct _nbMmeConfigTrnsf
@@ -479,8 +479,8 @@ EXTERN S16 NbUiNbtMsgReq(Pst *pst, NbtMsg *req);
 EXTERN Void nbUiSendSuccessResponseToUser(NbMsgTypes msgType);
 EXTERN S16 NbEnbCfgReqHdl(NbConfigReq   *cfg);
 EXTERN S16 nbUiSendResetAckToUser(NbResetAckldg *resetAck);
-EXTERN S16 nbUiSendUeCtxRelIndToUser(U8 ueId);
-EXTERN S16 nbUiSendIntCtxtSetupIndToUser(U8 ueId, U8 status);
+EXTERN S16 nbUiSendUeCtxRelIndToUser(U32 ueId);
+EXTERN S16 nbUiSendIntCtxtSetupIndToUser(U32 ueId, U8 status);
 EXTERN S16 nbUiSendErabRelCmdInfoToUser(NbErabRelCmd *erabRelInfo);
 /********************************************************************30**
 

--- a/TestCntlrApp/src/fw_cm/nbu.x
+++ b/TestCntlrApp/src/fw_cm/nbu.x
@@ -31,7 +31,7 @@ typedef struct _nbuSTmsi
 
 typedef struct _nbuUeAttachReq
 {
-    U8 ueId;
+    U32 ueId;
     U32 rrcCause;
     NbuSTmsi stmsi;
     TknStrOSXL nasPdu;
@@ -39,18 +39,18 @@ typedef struct _nbuUeAttachReq
 
 typedef struct _nbuUlNasMsg
 {
-   U8 ueId;
+   U32 ueId;
    TknStrOSXL  nasPdu;
 }NbuUlNasMsg;
 typedef struct _nbuUlRrcMsg
 {
-   U8 ueId;
+   U32 ueId;
    TknStrOSXL  rrcPdu;
 }NbuUlRrcMsg;
 
 typedef struct _nbuDlNasMsg
 {
-   U8 ueId;
+   U32 ueId;
    TknStrOSXL nasPdu;
 }NbuDlNasMsg;
 
@@ -131,14 +131,14 @@ typedef struct _nbuErabRelLst
 
 typedef struct _nbuErabRelIndLst
 {
-   U8 ueId;
+   U32 ueId;
    U8 numOfErabIds;
    U8 *erabIdLst;
 }NbuErabRelIndList;
 
 typedef struct _nbuErabsRelInfo
 {
-   U8 ueId;
+   U32 ueId;
    Bool nasPduPres;
    NbuErabRelLst *erabInfo;
    TknStrOSXL nasPdu;
@@ -146,7 +146,7 @@ typedef struct _nbuErabsRelInfo
 
 typedef struct _nbuErabsInfo
 {
-   U8 ueId;
+   U32 ueId;
    Bool nasPduPres;
    Bool ueRadCapRcvd;
    NbuErabLst *erabInfo;
@@ -155,17 +155,17 @@ typedef struct _nbuErabsInfo
 
 typedef struct _nbuS1RelInd
 {
-   U8 ueId;
+   U32 ueId;
 }NbuS1RelInd;
 
 typedef struct _nbuUeInActvInd
 {
-   U8 ueId;
+   U32 ueId;
 }NbuUeInActvInd;
 
 typedef struct _nbuUeIpInfoReq
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
 }NbuUeIpInfoReq;
 
@@ -210,7 +210,7 @@ typedef struct _tftPfs {
 } TftPfs;
 
 typedef struct _nbuUeIpInfoRsp {
-  U8 ueId;
+  U32 ueId;
   U8 bearerId;
   S8 IpAddr[20];
   BearerType berType;
@@ -221,13 +221,13 @@ typedef struct _nbuUeIpInfoRsp {
 
 typedef struct _nbuTunDelReq
 {
-   U8 ueId;
+   U32 ueId;
    U32 erabId;
 }NbuTunDelReq;
 
 typedef struct _nbuNotifyPlmnInfo
 {
-   U8 ueId;
+   U32 ueId;
    U8 plmnId[3];
 }NbuNotifyPlmnInfo;
 

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -114,7 +114,7 @@ typedef struct _ueUetErrInd
 {
    U32            msgType;
    U32            errCode;
-   U32            ueId[UE_IMSI_LENGTH]; 
+   U32            ueId[UE_IMSI_LENGTH];
 }UeUetErrInd;
 
 typedef struct _ueUetAppCfReq
@@ -718,7 +718,7 @@ typedef struct ueEsmTft
 }UeEsmTft;
 typedef struct _ueUetBearerAllocReq
 {
-   U32                  ueId;
+   U32                 ueId;
    U8                  bearerId;
    U8                  lnkEpsBearerId;
    UeEsmEpsQos         epsQos;

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -842,7 +842,7 @@ typedef struct _ueUetAuthRejInd
 }UeUetAuthRejInd;
 
 typedef struct _ueUetAuthFailure {
-  U8 ueId;
+  U32 ueId;
   U8 cause;
   U8 auts[14];
 } UeUetAuthFailure;

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -114,7 +114,7 @@ typedef struct _ueUetErrInd
 {
    U32            msgType;
    U32            errCode;
-   U8             ueId[UE_IMSI_LENGTH];
+   U32            ueId[UE_IMSI_LENGTH]; 
 }UeUetErrInd;
 
 typedef struct _ueUetAppCfReq
@@ -127,14 +127,14 @@ typedef struct _ueUetAppCfReq
 
 typedef struct _ueUetAppCfgCompInd
 {
-  U8 ueId;
+  U32 ueId;
   U8 cfgStatus;
   U8 cause;
 }UeUetAppCfgCompInd;
 
 typedef struct _ueUetCfgReq
 {
-   U8 ueId;       /*ue identity*/
+   U32 ueId;       /*ue identity*/
    U8 imsiLen;     /* len of IMSi inclusive of MCC+MNC+MSIN */
    U8 imsi[15];       /*Mobile subscriber identity*/
    U8 imei[16];       /*Mobile equipment identity*/
@@ -153,7 +153,7 @@ typedef struct _ueUetCfgReq
 
 typedef struct _ueUetCfgCompInd
 {
-  U8 ueId;
+  U32 ueId;
   U8 cfgStatus;
   U8 cause;
 }UeUetCfgCompInd;
@@ -305,7 +305,7 @@ typedef struct _ueUetAttachReq
 {
  /* UeId, Attach type, Old GUTI, Last TAI,PDN type,
 PDN APN */
-   U8 ueId;
+   U32 ueId;
    U8 mIdType;
    U8 useOldSecCtxt;
    U32 pdnType;
@@ -320,7 +320,7 @@ PDN APN */
 }UeUetAttachReq;
 
 typedef struct _ueUetPdnConReq {
-  U8 ueId;
+  U32 ueId;
   U32 pdnType;
   UeEmmNasPdnApn nasPdnApn;
   U8 reqType;
@@ -335,31 +335,31 @@ typedef struct _uePdnRejectInfo
 
 typedef struct _ueUetAttachRej
 {
-   U8 ueId;
+   U32 ueId;
    U8 cause;
 }UeUetAttachRej;
 
 typedef struct _ueUetTauReject
 {
-   U8 ueId;
+   U32 ueId;
    U8 cause;
 }UeUetTauReject;
 
 typedef struct _ueUetIdentReqInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 idType;
 }UeUetIdentReqInd;
 
 typedef struct _ueUetIdentRsp
 {
-   U8 ueId;
+   U32 ueId;
    U8 idType;
 }UeUetIdentRsp;
 
 typedef struct _ueUetAuthReqInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 rand[16];
    U8 autn[16];
    U8 sqn[6];
@@ -384,7 +384,7 @@ typedef struct _ueUetRandRcvd
 
 typedef struct _ueUetAuthRsp
 {
-   U8 ueId;
+   U32 ueId;
    UeUetSqnRcvd sqnRcvd;
    UeUetSqnRcvd maxSqnRcvd;
    UeUetRandRcvd randRcvd;
@@ -393,7 +393,7 @@ typedef struct _ueUetAuthRsp
 
 typedef struct _ueUetSecModeCmdInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 NasCyphCfg;
    U8 NasIntProtCfg;
    U8 Kasme[UE_APP_KASME_KEY];
@@ -404,12 +404,12 @@ typedef struct _ueUetSecModeCmdInd
 
 typedef struct _ueUetSecModeComplete
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetSecModeComplete;
 
 typedef struct _ueUetSecModeReject
 {
-   U8 ueId;
+   U32 ueId;
    U8 cause;
 }UeUetSecModeReject;
 
@@ -488,7 +488,7 @@ typedef struct _uePdnInfo
 
 typedef struct _ueUetPdnConRsp
 {
-   U8             ueId;
+   U32             ueId;
    U8             status; /* ROK/RFAILED */
    union
    {
@@ -499,7 +499,7 @@ typedef struct _ueUetPdnConRsp
 
 typedef struct _ueUetAttachAcceptInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 epsAtchRes;
    U16 t3412;
    Guti guti;
@@ -514,12 +514,12 @@ typedef struct _ueUetAttachAcceptInd
 
 typedef struct _ueUetAttachComplete
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetAttachComplete;
 
 typedef struct _ueUetAttachFail
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetAttachFail;
 
 typedef enum _ueUetDetachType
@@ -537,13 +537,13 @@ typedef enum _ueUetNwInitDetachType
 
 typedef struct _ueUetDetachReq
 {
-   U8 ueId;
+   U32 ueId;
    UeUetDetachType ueDetType;
 }UeUetDetachReq;
 
 typedef struct _ueUetNwInitDetachReq
 {
-   U8 ueId;
+   U32 ueId;
    UeUetNwInitDetachType ueNwInitDetType;
    U8 cause;
 }UeUetNwInitDetachReq;
@@ -556,19 +556,19 @@ typedef struct _ueUetMtmsi
 
 typedef struct _ueUetServiceReq
 {
-   U8 ueId;
+   U32 ueId;
    UeUetMtmsi ueMtmsi;
    U8 rrcCause;
 }UeUetServiceReq;
 
 typedef struct _ueUetServiceRej
 {
-   U8 ueId;
+   U32 ueId;
    U8 cause;
 }UeUetServiceRej;
 typedef struct _ueUetRadCapUpdReq
 {
-   U8 ueId;
+   U32 ueId;
    Bool send_s1ap_msg;
    Bool upd_ueRadCap;
    U16 len;
@@ -577,23 +577,23 @@ typedef struct _ueUetRadCapUpdReq
 
 typedef struct _ueUetPagingMsg
 {
-   U8 ueId;
+   U32 ueId;
    U8 domainType;
 }UeUetPagingMsg;
 
 typedef struct _ueUetDetachReqAccept
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetDetachAcceptInd;
 
 typedef struct _ueUetUeTrigDetachAccept
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetUeTrigDetachAccept;
 
 typedef struct _ueUetTauRequest
 {
-   U8 ueId;
+   U32 ueId;
    UeUetMtmsi ueMtmsi;
    U8 epsUpdtType;
    U8 ActvFlag;
@@ -601,7 +601,7 @@ typedef struct _ueUetTauRequest
 
 typedef struct _ueUetTauAccept
 {
-   U8 ueId;
+   U32 ueId;
    U8 epsUpdateRes;
    U8 gutiChanged;
    Guti guti;
@@ -609,7 +609,7 @@ typedef struct _ueUetTauAccept
 
 typedef struct _ueUetTauComplete
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetTauComplete;
 
 typedef struct _ueUetFlush
@@ -717,7 +717,7 @@ typedef struct ueEsmTft
 }UeEsmTft;
 typedef struct _ueUetBearerAllocReq
 {
-   U8                  ueId;
+   U32                  ueId;
    U8                  bearerId;
    U8                  lnkEpsBearerId;
    UeEsmEpsQos         epsQos;
@@ -726,7 +726,7 @@ typedef struct _ueUetBearerAllocReq
 /*Erab Release Indication*/
 typedef struct UeErabRelInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 numOfErabIds;
    U8 *erabIdLst;
 }UeErabRelInd;
@@ -771,7 +771,7 @@ typedef struct _ueEsmTxnId
 /* cm_esm_x_001.main_1: Activate dedicated EPS bearer context request */
 typedef struct ueUetActDedBearCtxtReq
 {
-   U8                ueId;
+   U32               ueId;
    U8                bearerId;
    U8                lnkBearerId;
    UeEsmEpsQos       epsQos;
@@ -789,7 +789,7 @@ typedef struct ueUetActDedBearCtxtReq
 /* Activate dedicated EPS bearer context accept message */
 typedef struct ueEsmActDedBearCtxtAcc
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
 # if 0
    UeEsmProtCfgOpt   protCfgOpt;
@@ -797,7 +797,7 @@ typedef struct ueEsmActDedBearCtxtAcc
 }UeEsmActDedBearCtxtAcc;
 typedef struct ueEsmActDedBearCtxtRej
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
    U8 esmCause;
 # if 0
@@ -808,7 +808,7 @@ typedef struct ueEsmActDedBearCtxtRej
 /* cm_esm_x_001.main_1: De-Activate EPS bearer context request */
 typedef struct ueUetDeActvBearCtxtReq
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
    U8 esmCause;
 }UeUetDeActvBearCtxtReq;
@@ -816,13 +816,13 @@ typedef struct ueUetDeActvBearCtxtReq
 /* cm_esm_x_001.main_1: De-Activate EPS bearer context accept */
 typedef struct ueUetDeActvBearCtxtAcc
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
 }UeUetDeActvBearCtxtAcc;
 
 typedef struct ueEsmActDfltBearCtxtRej
 {
-   U8 ueId;
+   U32 ueId;
    U8 bearerId;
    U8 esmCause;
 # if 0
@@ -832,43 +832,43 @@ typedef struct ueEsmActDfltBearCtxtRej
 
 typedef struct _ueUetEmmInformation
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetEmmInformation;
 
 typedef struct _ueUetAuthRejInd
 {
-   U8 ueId;
+   U32 ueId;
 }UeUetAuthRejInd;
 
 typedef struct _ueUetEmmStatus
 {
-   U8 ueId;
+   U32 ueId;
    U8 cause;
 }UeUetEmmStatus;
 
 typedef struct _ueUetEsmInformationReq
 {
-   U8 ueId;
+   U32 ueId;
    U8 tId;
 }UeUetEsmInformationReq;
 
 typedef struct _ueUetEsmInformationRsp
 {
-   U8 ueId;
+   U32 ueId;
    U8 tId;
    UeEmmNasPdnApn  nasPdnApn;
 }UeUetEsmInformationRsp;
 
 /* PDN Disconnect Request message */
 typedef struct _ueUetPdnDisconnectReq {
-  U8 ueId;
+  U32 ueId;
   U8 bearerId;
 } UeUetPdnDisconnectReq;
 
 /* PDN Disconnect Reject*/
 typedef struct _ueUetPdnDisconnectRej
 {
-  U8 ueId;
+  U32 ueId;
   U8 cause;
 }UeUetPdnDisconnectRej;
 
@@ -879,7 +879,7 @@ typedef struct _uetFailedErablist {
 } UetFailedErablist;
 
 typedef struct _ueUetErabSetupFailedTosetup {
-  U8 ueId;
+  U32 ueId;
 #define MAX_FAILED_ERABS 11
   U8 noOfFailedErabs;
   UetFailedErablist failedErablist[MAX_FAILED_ERABS];

--- a/TestCntlrApp/src/ssi/envopt.h
+++ b/TestCntlrApp/src/ssi/envopt.h
@@ -105,7 +105,7 @@
 #ifdef MULTI_ENB_SUPPORT_ENABLE
 #define MULTI_ENB_SUPPORT
 #endif
-#define MAX_UE_INST 255
+#define MAX_UE_INST 32768
 #define MAX_ENB_INST 1000
 
 /* error checking, choose none or one */

--- a/TestCntlrApp/src/tfwApp/fw.x
+++ b/TestCntlrApp/src/tfwApp/fw.x
@@ -43,7 +43,7 @@ typedef enum
 typedef struct _ueIdCb
 {
    CmLList link;
-   U8 ue_id;
+   U32 ue_id;
    attachState state;
    struct fwTmrCb  *tmrCb; /* Defines Timer control block */ 
    U8 epsUpdType;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -1569,11 +1569,11 @@ PUBLIC S16 handleResetRequest(ResetReq *data)
    {
       msgReq->t.resetReq.u.partialRst.numOfConn = data->r.partialRst.numOfConn;
       FW_ALLOC_MEM(fwCb, &msgReq->t.resetReq.u.partialRst.ueIdLst,
-            msgReq->t.resetReq.u.partialRst.numOfConn);
+            msgReq->t.resetReq.u.partialRst.numOfConn*sizeof(U32));
 
       cmMemcpy(msgReq->t.resetReq.u.partialRst.ueIdLst,
             data->r.partialRst.ueIdLst,
-            msgReq->t.resetReq.u.partialRst.numOfConn);
+            msgReq->t.resetReq.u.partialRst.numOfConn*sizeof(U32));
    }
    else
    {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -108,7 +108,7 @@ PUBLIC FwCb gfwCb;
 /* Adding UEID, epsupdate type, active flag into linked list for
  * TAU request
  */
-PRIVATE Void insertUeCb(U8 ueid, U8 epsUpdType, U8 flag, UeIdCb *ueIdCb)
+PRIVATE Void insertUeCb(U32 ueid, U8 epsUpdType, U8 flag, UeIdCb *ueIdCb)
 {
    FwCb *fwCb = NULLP;
    FW_GET_CB(fwCb);
@@ -580,7 +580,7 @@ PUBLIC S16 handlRadCapUpd(ueRadCapUpd_t *data)
 }
 
 /* Adding UEID into linked list for END TO END ATTACH */
-PRIVATE Void insert_ue_entry(U8 ueid, UeIdCb *ueIdCb)
+PRIVATE Void insert_ue_entry(U32 ueid, UeIdCb *ueIdCb)
 {
    FwCb *fwCb = NULLP;
    FW_GET_CB(fwCb);

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -674,7 +674,7 @@ typedef struct ueAppConfigCompleteInd
 
 typedef struct ueConfig
 {
-   U8 ue_id;
+   U32 ue_id;
    U8 imsiLen;
    U8 imsi[15];
    U8 imei[16];
@@ -692,7 +692,7 @@ typedef struct ueConfig
 
 typedef struct ueRadCapConfig
 {
-   U8 ue_id;
+   U32 ue_id;
    Bool snd_ueCapInd;
    Bool upd_ueCapInfo;
    U16 rrcMsgLen;
@@ -707,7 +707,7 @@ typedef struct ueConfigCompleteInd
 
 typedef struct ueAttachRequest
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 mIdType;
    U8 epsAttachType;
    U8 useOldSecCtxt;
@@ -723,7 +723,7 @@ typedef struct ueAttachRequest
 
 typedef struct ueAuthReqInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 randm[16];
    U8 autn[16];
    U8 sqn[6];
@@ -746,7 +746,7 @@ typedef struct ueRandRcvd
 
 typedef struct ueAuthResp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    ueSqnRcvd_t sqnRcvd;
    ueSqnRcvd_t maxSqnRcvd;
    Bool nonEPSAuthFail; /* Simulate Auth Resp with Cause #26 - non-EPS authentication unacceptable*/
@@ -755,7 +755,7 @@ typedef struct ueAuthResp
 
 typedef struct ueSecModeCmdInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 nas_cyp_cfg;
    U8 nas_int_prot_cfg;
    U8 kasme[MAX_KASME_KEY];
@@ -766,12 +766,12 @@ typedef struct ueSecModeCmdInd
 
 typedef struct ueSecModeComplete
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueSecModeComplete_t;
 
 typedef struct ueSecModeReject
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 cause;
 }ueSecModeReject_t;
 
@@ -843,7 +843,7 @@ typedef struct ueEsmInfo
 
 typedef struct ueAttachAccept
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 eps_Atch_resp;
    U16 t3412;
    cmGUTI guti;
@@ -858,18 +858,18 @@ typedef struct ueAttachAccept
 
 typedef struct ueAttachComplete
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueAttachComplete_t;
 /*This message sent along with attach complete */
 typedef struct ueActvDfltEpsBearerCtxtRej
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 bearerId;
    U8 cause;
 }ueActvDfltEpsBearerCtxtRej_t;
 typedef struct ueAttachFail
 {
-   U8 ueId;
+   U32 ueId;
    U8 ueState;
    U16 reason;
 }ueAttachFail_t;
@@ -882,7 +882,7 @@ typedef enum ueDetachType
 
 typedef struct ueDetachReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    ueDetachType_t ueDetType;
 }uedetachReq_t;
 
@@ -895,7 +895,7 @@ typedef enum ueNwInitDetType
 
 typedef struct ueNwInitDetachReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    ueNwInitDetType_t Type;
    U8 cause;
 }ueNwInitdetachReq_t;
@@ -908,7 +908,7 @@ typedef struct ueMtmsi
 
 typedef struct ueServiceReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    ueMtmsi_t ueMtmsi;
    U8 rrcCause;
 }ueserviceReq_t;
@@ -921,12 +921,12 @@ typedef struct _relCause
 
 typedef struct ueCntxtRelReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    RelCause cause;
 }ueCntxtRelReq_t;
 
 typedef struct uepdnConReq {
-  U8 ue_Id;
+  U32 ue_Id;
   U8 reqType;
   pdn_Type pdnType_pr;
   pdn_APN pdnAPN_pr;
@@ -934,7 +934,7 @@ typedef struct uepdnConReq {
 } uepdnConReq_t;
 
 typedef struct uepdnDisconnectReq {
-  U8 ue_Id;
+  U32 ue_Id;
   U8 epsBearerId;
 } uepdnDisconnectReq_t;
 
@@ -972,7 +972,7 @@ typedef struct _fwCriticalityDiag
 typedef struct fwNbErrIndMsg
 {
    U8   isUeAssoc;
-   U8   ue_Id;
+   U32   ue_Id;
    ErrCause cause;
    FwCriticalityDiag criticalityDiag;
 }fwNbErrIndMsg_t;
@@ -993,7 +993,7 @@ typedef struct _ue_Pdn_Info
 
 typedef struct uepdnConRsp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 status;
    union
    {  pdnConRejInfo_t conRejInfo;
@@ -1003,46 +1003,46 @@ typedef struct uepdnConRsp
 
 typedef struct uePdnConTimeOutInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }uePdnConTimeOutInd_t;
 
 typedef struct ueServiceRejInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 cause;
 }ueServiceRejInd_t;
 
 typedef struct ueDetachAcceptInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueDetachAcceptInd_t;
 
 typedef struct ueTrigDetachAcceptInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueTrigDetachAcceptInd_t;
 
 typedef struct ueAttachRejInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 cause;
 }ueAttachRejInd_t;
 
 typedef struct ueIdentityReqInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 idType;
 }ueIdentityReqInd_t;
 
 typedef struct ueIdentityResp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 idType;
 }ueIdentityResp_t;
 
 typedef struct ueTauReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    ueMtmsi_t ueMtmsi;
    Eps_Updt_Type type;
    U8 Actv_flag;
@@ -1050,7 +1050,7 @@ typedef struct ueTauReq
 
 typedef struct ueTauAccept
 {
-   U8 ue_Id;
+   U32 ue_Id;
    cmGUTI guti;
    U8 epsUpdateRes;
    U8 gutiChanged;
@@ -1058,19 +1058,19 @@ typedef struct ueTauAccept
 
 typedef struct ueTauRejInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 cause;
 }ueTauRejInd_t;
 
 typedef struct uePagingInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 domain_Type;
 }uePagingInd_t;
 
 typedef struct ueTauComplete
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueTauComplete_t;
 
 typedef struct ueFlush
@@ -1178,7 +1178,7 @@ typedef struct _ueEsmTft
 
 typedef struct ueBearerAllocReq
 {
-   U8              ue_Id;
+   U32              ue_Id;
    U8              bearerId;
    U8              lnkEpsBearerId;
    ue_Esm_Eps_Qos  qos;
@@ -1220,7 +1220,7 @@ typedef struct _EsmTxnId
 }ue_Esm_TxnId;
 typedef struct ueActDedBearCtxtReq
 {
-   U8                   ue_Id;
+   U32                  ue_Id;
    U8                   bearerId;
    ue_Esm_Eps_Qos       epsQos;
    ue_Esm_Tft           tft;
@@ -1235,27 +1235,27 @@ typedef struct ueActDedBearCtxtReq
 
 typedef struct ueActDedBearCtxtAcc
 {
-   U8                   ue_Id;
+   U32                  ue_Id;
    U8                   bearerId;
 }UeActDedBearCtxtAcc_t;
 
 typedef struct ueActDedBearCtxtRej
 {
-   U8                   ue_Id;
+   U32                   ue_Id;
    U8                   bearerId;
    U8                   esmCause;
 }UeActDedBearCtxtRej_t;
 
 typedef struct ueDeActvBearCtxtReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 bearerId;
    U8 esmCause;
 }UeDeActvBearCtxtReq_t;
 
 typedef struct ueDeActvBearCtxtAcc
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 bearerId;
 }UeDeActvBearCtxtAcc_t;
 
@@ -1299,46 +1299,46 @@ typedef enum
 }NasNonDelCauseValTport;
 typedef struct ueNasNonDel
 {
-   U8 ue_Id;
+   U32 ue_Id;
    Bool flag;
    NasNonDelCauseType causeType;
    U32 causeVal;
 }UeNasNonDel;
 typedef struct ueInitCtxtSetupFail
 {
-   U8 ue_Id;
+   U32 ue_Id;
    Bool flag;
    U8 causeType;
    U32 causeVal;
 }ueInitCtxtSetupFail;
 typedef struct ueDropInitCtxtSetup
 {
-   U8 ue_Id;
+   U32 ue_Id;
    Bool flag;
    U32 tmrVal;
 }UeDropInitCtxtSetup;
 typedef struct ueDelayInitCtxtSetupRsp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U32 tmrVal;
    Bool flag;
 }UeDelayInitCtxtSetupRsp;
 typedef struct ueDelayUeCtxtRelCmp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U32 tmrVal;
    Bool flag;
 }UeDelayUeCtxtRelCmp;
 typedef struct ueSetCtxtRelForInitCtxtSetup
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 causeType;
    U32 causeVal;
    Bool flag;
 }UeSetCtxtRelForInitCtxtSetup;
 typedef struct ueNasNonDelRsp
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueNasNonDelRsp_t;
 
 typedef struct _num_Of_Enbs
@@ -1404,7 +1404,7 @@ typedef struct _fwNbS1SetupRsp
 
 typedef struct ueRadCapUpd
 {
-   U8 ue_Id;
+   U32 ue_Id;
    Bool snd_S1AP;
    radio_Cpblty radioCap_pr;
 }ueRadCapUpd_t;
@@ -1423,8 +1423,8 @@ typedef struct _CompleteReset
 
 typedef struct _PartialReset
 {
-   U16 numOfConn;
-   U8 *ueIdLst;
+   U32 numOfConn;
+   U32 *ueIdLst;
 }PartialReset;
 
 typedef struct _cause
@@ -1447,20 +1447,20 @@ typedef struct _resetReq
 typedef struct _fwNbS1ResetAck
 {
    U8 status;
-   U16 numOfUes;
-   U8 *ueIdLst;
+   U32 numOfUes;
+   U32 *ueIdLst;
 }FwNbS1ResetAck_t;
 
 typedef struct _fwErabRelInd_t
 {
-   U8 ueId;
+   U32 ueId;
    U8 numOfErabIds;
    U8 *erabIdLst;
 }FwErabRelInd_t;
 
 typedef struct _fwFwErabRelCmd_t
 {
-   U8 ueId;
+   U32 ueId;
    U32 enbUeS1apId;
    U32 mmeUeS1apId;
    U8 numOfErabIds;
@@ -1469,45 +1469,45 @@ typedef struct _fwFwErabRelCmd_t
 
 typedef struct _fwNbUeCtxRelInd
 {
-   U8 ueId;
+   U32 ueId;
 }FwNbUeCtxRelInd_t;
 
 typedef struct _fwNbIntCtxSetupInd
 {
-   U8 ueId;
+   U32 ueId;
    U8 status;
 }FwNbIntCtxSetupInd_t;
 
 typedef struct _fwNbIntCtxSetupDrpdInd
 {
-   U8 ueId;
+   U32 ueId;
 }FwNbIntCtxSetupDrpdInd_t;
 
 typedef struct UeEmmInformation
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueEmmInformation_t;
 
 typedef struct UeAuthRejInd
 {
-   U8 ue_Id;
+   U32 ue_Id;
 }ueAuthRejInd_t;
 
 typedef struct UeEmmStatus
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 cause;
 }ueEmmStatus_t;
 
 typedef struct UeEsmInformationReq
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 tId;
 }ueEsmInformationReq_t;
 
 typedef struct UeEsmInformationRsp
 {
-   U8 ue_Id;
+   U32 ue_Id;
    U8 tId;
    pdn_APN  pdnAPN_pr;
 }ueEsmInformationRsp_t;
@@ -1528,7 +1528,7 @@ typedef struct MultiEnbConfigReq
 
 typedef struct _fwNbPathSwReqAck
 {
-   U8 ueId;
+   U32 ueId;
 }FwNbPathSwReqAck_t;
 
 typedef struct _fwNbMmeConfigTrnsf
@@ -1542,7 +1542,7 @@ typedef struct _fwNbMmeConfigTrnsf
 
 typedef struct uePdnDisconnFail
 {
-   U8 ueId;
+   U32 ueId;
 }uePdnDisconnFail_t;
 
 typedef struct _FwFailedErablist {
@@ -1552,7 +1552,7 @@ typedef struct _FwFailedErablist {
 } FwFailedErablist;
 
 typedef struct _FwErabSetupFailedTosetup {
-  U8 ueId;
+  U32 ueId;
   U8 noOfFailedErabs;
   FwFailedErablist failedErablist[MAX_FAILED_ERABS];
 } FwErabSetupFailedTosetup;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -973,7 +973,7 @@ typedef struct _fwCriticalityDiag
 typedef struct fwNbErrIndMsg
 {
    U8   isUeAssoc;
-   U32   ue_Id;
+   U32  ue_Id;
    ErrCause cause;
    FwCriticalityDiag criticalityDiag;
 }fwNbErrIndMsg_t;
@@ -1179,7 +1179,7 @@ typedef struct _ueEsmTft
 
 typedef struct ueBearerAllocReq
 {
-   U32              ue_Id;
+   U32             ue_Id;
    U8              bearerId;
    U8              lnkEpsBearerId;
    ue_Esm_Eps_Qos  qos;
@@ -1242,7 +1242,7 @@ typedef struct ueActDedBearCtxtAcc
 
 typedef struct ueActDedBearCtxtRej
 {
-   U32                   ue_Id;
+   U32                  ue_Id;
    U8                   bearerId;
    U8                   esmCause;
 }UeActDedBearCtxtRej_t;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -1495,7 +1495,7 @@ typedef struct UeAuthRejInd
 }ueAuthRejInd_t;
 
 typedef struct UeAuthFailure {
-  U8 ue_Id;
+  U32 ue_Id;
   U8 cause;
   U8 auts[TFW_AUTS_LEN];
 } ueAuthFailure_t;

--- a/TestCntlrApp/src/tfwApp/fw_read_dflcfg.h
+++ b/TestCntlrApp/src/tfwApp/fw_read_dflcfg.h
@@ -49,7 +49,7 @@ typedef struct _ueAppCfgCb
 
 typedef struct _ueCfgCb
 {
-   U8 ueId;       /*ue identity*/
+   U32 ueId;       /*ue identity*/
    U8 imsi[16];       /*Mobile subscriber identity*/
    U8 imei[16];       /*Mobile equipment identity*/
    U8 NASCyphCfg;          /*eea0, eea1, eea2*/

--- a/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
+++ b/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
@@ -109,7 +109,7 @@ PUBLIC S16 handlePagingInd( Pst *pst,  UetMessage *uetPagingtInd);
 PUBLIC S16 sendUePagingIndToTstCntlr(UetMessage *uetPagingInd);
 PRIVATE S16 handleNwInitDetachReqInd(Pst *pst, UetMessage *uetNwinitDetachInd);
 PUBLIC S16 sendUeNwInitDetachReqIndToTstCntlr(UetMessage *uetNwInitDetachInd);
-PRIVATE Void delete_ue_entries(U8);
+PRIVATE Void delete_ue_entries(U32);
 PRIVATE S16 handleAndSendActDedBerReqInd (Pst *pst, UetMessage *msgreq);
 PRIVATE S16 handleAndSendDeActvBerReqInd (Pst *pst, UetMessage *msgreq);
 PRIVATE S16 handleEmmInformation ( Pst *pst,  UetMessage *ueEmmInformation);
@@ -989,7 +989,7 @@ PUBLIC S16 handleTauAcceptInd
 }
 
 /* Deleting the ueid entries from the linked list */
-PRIVATE Void delete_ue_entries(U8 ueId)
+PRIVATE Void delete_ue_entries(U32 ueId)
 {
    FwCb *fwCb = NULLP;
    CmLList  *tmpNode = NULLP;

--- a/TestCntlrApp/src/ueApp/ueAppdbm.x
+++ b/TestCntlrApp/src/ueApp/ueAppdbm.x
@@ -121,7 +121,7 @@ typedef struct _ueNwCap
 
 typedef struct _ueConfigInfo
 {
-   U8 ueId;       /*ue identity*/
+   U32 ueId;       /*ue identity*/
    U8 imsi[MAX_IMSI_LEN];       /*Mobile subscriber identity*/
    U8 imei[MAX_IMEI_LEN];       /*Mobile equipment identity*/
    U8 NASCyphCfg;          /*eea0, eea1, eea2*/
@@ -269,7 +269,7 @@ typedef struct _ueCb
    U32         transIdCntr;   /* Transaction counter for sending the 
                                  ESM Procedural transactions. */
    U16         cellId; /* cellId */
-   U16         ueId;   /* ueId */
+   U32         ueId;   /* ueId */
    U8          nasEsmState;  /* NAS State */
    U8          hoState;      /* HO State */
    Bool        drpSecMode;
@@ -310,7 +310,7 @@ typedef struct _ueAppCb
    CmHashListCp     ueLstCp; /*!< Hashlist of UeCb */
 #else
    UeCb             *ueCbLst[UE_APP_MAX_NUM_OF_UES];
-   U8               numOfUesInLst;
+   U32               numOfUesInLst;
 #endif
 }UeAppCb;
 

--- a/TestCntlrApp/src/ueApp/ueAppdbm.x
+++ b/TestCntlrApp/src/ueApp/ueAppdbm.x
@@ -310,7 +310,7 @@ typedef struct _ueAppCb
    CmHashListCp     ueLstCp; /*!< Hashlist of UeCb */
 #else
    UeCb             *ueCbLst[UE_APP_MAX_NUM_OF_UES];
-   U32               numOfUesInLst;
+   U32              numOfUesInLst;
 #endif
 }UeAppCb;
 

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -86,14 +86,14 @@ EXTERN S16 ueSendToTfwApp(UetMessage*, Pst*);
 EXTERN S16 ueSendInitialUeMsg(NbuInitialUeMsg*, Pst*);
 EXTERN S16 ueSendUlNasMsgToNb(NbuUlNasMsg*, Pst*);
 EXTERN S16 ueSendUlRrcMsgToNb(NbuUlRrcMsg*, Pst*);
-EXTERN S16 ueDbmFetchUe(U8, PTR*);
+EXTERN S16 ueDbmFetchUe(U32, PTR*);
 EXTERN S16 ueDbmAddUe(UeCb*);
 EXTERN S16 ueDbmDelAllUe(Void);
 EXTERN S16 ueDbmInit(Void);
 EXTERN S16 ueDbmDeInit(Void);
 EXTERN S16 ueAppBldAndSndIpAddrToNb(U8, U8*, U8, Pst*);
 EXTERN S16 ueDbmFetchUeWithS_TMSI(UePagingMsg*, PTR*);
-EXTERN S16 ueDbmDelUe(UeAppCb*, U8);
+EXTERN S16 ueDbmDelUe(UeAppCb*, U32);
 EXTERN S16 ueUiProcErabsInfoMsg(Pst*, NbuErabsInfo*);
 EXTERN S16 ueAppBldAndSndIpInfoRspToNb(UeCb*, U8, Pst*);
 PUBLIC S16 ueSendErabRelInd(NbuErabRelIndList*, Pst*);
@@ -660,7 +660,7 @@ PRIVATE S16 ueAppSndAuthResponse(UeCb *ueCb, UeSQN sqnRcvd,UeSQN maxSqnRcvd,UeRa
 PRIVATE S16 ueProcUeIdentResp(UetMessage *tfwMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -704,7 +704,7 @@ PRIVATE S16 ueProcUeIdentResp(UetMessage *tfwMsg, Pst *pst)
 PRIVATE S16 ueProcUeAuthResp(UetMessage *tfwMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeSQN sqnRcvd    = {0};
    UeSQN maxSqnRcvd = {0};
    UeRand randRcvd  = {0};
@@ -1946,7 +1946,7 @@ PRIVATE S16 ueProcUeAttachReq(UetMessage *p_ueMsg, Pst *pst)
    UeEmmDrxPrm    *drxParm;
    Bool eti = FALSE;
    S16     ret = ROK;
-   U16     ueId;
+   U32     ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb    *ueCb = NULLP;
    NhuDedicatedInfoNAS nasEncPdu;
@@ -2094,7 +2094,7 @@ PRIVATE S16 ueProcUeTauRequest(UetMessage *p_ueMsg, Pst *pst)
 {
    U8 isPlainMsg = TRUE;
    S16     ret = ROK;
-   U16     ueId = 0;
+   U32     ueId = 0;
    UeAppCb *ueAppCb = NULLP;
    UeCb    *ueCb = NULLP;
    UeAppMsg srcMsg;
@@ -2211,7 +2211,7 @@ PRIVATE S16 ueProcUeTauComplete(UetMessage *p_ueMsg, Pst *pst)
 {
    U8 isPlainMsg = TRUE;
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
    UeAppMsg srcMsg;
@@ -3367,7 +3367,7 @@ PRIVATE S16 ueAppSndAttachComplete(UeCb *ueCb)
 PRIVATE S16 ueProcUeAttachComplete(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -3404,7 +3404,7 @@ PRIVATE S16 ueProcUeAttachComplete(UetMessage *p_ueMsg, Pst *pst)
 PRIVATE S16 ueProcUeAttachCompleteWithActvDfltBerCtxtRej(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -3443,7 +3443,7 @@ PRIVATE S16 ueProcUeAttachCompleteWithActvDfltBerCtxtRej(UetMessage *p_ueMsg, Ps
 PRIVATE S16 ueProcUeAttachFail(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    UeAppCb *ueAppCb = NULLP;
 
    UE_GET_CB(ueAppCb);
@@ -3482,7 +3482,7 @@ PRIVATE S16 ueProcUeAttachFail(UetMessage *p_ueMsg, Pst *pst)
 PRIVATE S16 ueProcUeSecModeRejectCmd(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
    U8           cause;
@@ -3575,7 +3575,7 @@ PRIVATE S16 ueProcUeSecModeRejectCmd(UetMessage *p_ueMsg, Pst *pst)
 PRIVATE S16 ueProcUeSecModeCmdComplete(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
    UeAppMsg     srcMsg;
@@ -3928,7 +3928,7 @@ PRIVATE S16 ueProcUeDetachRequest
 )
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    U8 detCause;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
@@ -4192,7 +4192,7 @@ PRIVATE S16 ueProcUeTrigDetachAcc
 )
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -4275,7 +4275,7 @@ PRIVATE S16 ueProcErabRelInd
    S16 ret = ROK;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
-   U16 ueId;
+   U32 ueId;
 
    UE_GET_CB(ueAppCb);
    UE_LOG_ENTERFN(ueAppCb);
@@ -4585,7 +4585,7 @@ PRIVATE S16 ueProcUePdnConReq
 )
 {
    S16 ret = ROK;
-   U8  ueId = 0;
+   U32  ueId = 0;
    U8 isPlainMsg = TRUE;
    UeAppMsg srcMsg;
    UeAppMsg dstMsg;
@@ -5035,7 +5035,7 @@ PRIVATE S16 ueProcUeServiceRequest
 )
 {
    S16 ret = ROK;
-   U8  ueId = 0;
+   U32  ueId = 0;
    U32 mTmsi = 0;
    U8 rrcCause = 0;
    UeAppCb *ueAppCb = NULLP;
@@ -5124,7 +5124,7 @@ PRIVATE S16 ueProcUeRadCapUpdateReq
 )
 {
    S16 ret = ROK;
-   U8  ueId = 0;
+   U32  ueId = 0;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -5263,7 +5263,7 @@ PRIVATE S16 ueAppSndEmmStatus(UeCb *ueCb, U8 cause)
 PRIVATE S16 ueProcUeEmmStatus(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8  ueId;
+   U32  ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -7536,7 +7536,7 @@ PRIVATE S16 ueAppEmmHdlIncUeEvnt(CmNasEvnt *ueEvnt, UeCb *ueCb)
 PUBLIC S16 ueUiProcessNbMsg(NbuDlNasMsg *pNbDlMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
    UeAppMsg     srcMsg;
@@ -7723,7 +7723,7 @@ PUBLIC S16 ueUiProcErabsRelInfoMsg(Pst *pst, NbuErabsRelInfo *pNbuErabsRelInfo)
 {
    int i = 0;
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeAppMsg     srcMsg;
    UeAppMsg     dstMsg;
@@ -7816,7 +7816,7 @@ PUBLIC S16 ueUiProcErabsInfoMsg(Pst *pst, NbuErabsInfo *pNbuErabsInfo)
 {
    int i = 0;
    S16 ret = ROK;
-   U16 ueId;
+   U32 ueId;
    UeAppCb *ueAppCb = NULLP;
    UeAppMsg     srcMsg;
    UeAppMsg     dstMsg;
@@ -7939,7 +7939,7 @@ PRIVATE S16 ueProcUeBearResAllocReq
 )
 {
    CmNasEvnt           *reqEvnt = NULLP;
-   U16 ueId;
+   U32 ueId;
    U8                   isPlainMsg   = TRUE;
    UeCb *ueCb = NULLP;
    S16 ret;
@@ -8051,7 +8051,7 @@ PRIVATE S16 ueProcUeDeActvBerAcc
  Pst *pst
 )
 {
-   U16 ueId;
+   U32 ueId;
    UeCb *ueCb = NULLP;
    S16 ret;
    UeAppCb *ueAppCb;
@@ -8094,7 +8094,7 @@ PRIVATE S16 ueProcUeActvDedBerAcc
  Pst *pst
 )
 {
-   U16 ueId;
+   U32 ueId;
    UeCb *ueCb = NULLP;
    S16 ret;
    UeAppCb *ueAppCb;
@@ -8139,7 +8139,7 @@ PRIVATE S16 ueProcUeActvDedBerRej
  Pst *pst
 )
 {
-   U16 ueId;
+   U32 ueId;
    U8  bearerId;
    U8 esmCause;
    UeCb *ueCb = NULLP;
@@ -9085,7 +9085,7 @@ PRIVATE S16 ueAppUtlBldEsmInformationRsp
 PRIVATE S16 ueProcUeEsmInformationRsp(UetMessage *p_ueMsg, Pst *pst)
 {
    S16 ret = ROK;
-   U8  ueId = 0;
+   U32  ueId = 0;
    U8 isPlainMsg = TRUE;
    UeAppMsg srcMsg;
    UeAppMsg dstMsg;
@@ -9250,7 +9250,7 @@ PRIVATE S16 ueAppUtlBldStandAlonePdnDisconnectReq
  */
 PRIVATE S16 ueProcUePdnDisconnectReq(UetMessage *p_ueMsg, Pst *pst) {
   S16 ret = ROK;
-  U8 ueId = 0;
+  U32 ueId = 0;
   U8 isPlainMsg = TRUE;
   UeAppMsg srcMsg;
   UeAppMsg dstMsg;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -816,7 +816,7 @@ PRIVATE S16 ueProcUeAuthResp(UetMessage *tfwMsg, Pst *pst)
  */
 PRIVATE S16 ueProcUeAuthFailure(UetMessage *tfwMsg, Pst *pst) {
   S16 ret = ROK;
-  U16 ueId;
+  U32 ueId;
 
   UeAppCb *ueAppCb = NULLP;
   UeCb *ueCb = NULLP;

--- a/TestCntlrApp/src/ueApp/ue_app.x
+++ b/TestCntlrApp/src/ueApp/ue_app.x
@@ -191,7 +191,7 @@ typedef struct _ueEmmSecModeCmd
 /* Security Mode Complete message structure */
 typedef struct _ueEmmSecModeCmp
 {
-  U32 ueId; 
+  U32 ueId;
   /* TODO */
 }UeEmmSecModeCmp;
 

--- a/TestCntlrApp/src/ueApp/ue_app.x
+++ b/TestCntlrApp/src/ueApp/ue_app.x
@@ -98,7 +98,7 @@ typedef struct _nasPdnApn
 /* UE Attach request message structure */
 typedef struct _ueAttachReq
 {
-     U8 ueId;
+     U32 ueId;
      U8 attachType;
      U8 pdnType;
      U32 oldGuti; /*Check*/
@@ -146,7 +146,7 @@ typedef struct _ueAuthPrmXRES
 /* Auth Request Indication message structure */
 typedef struct _ueAuthReq
 {
-   U8 ueId;
+   U32 ueId;
    UeAuthPrmRAND authRAND;
    UeAuthPrmAUTHN authUTHN;
    UeNasKsi nasKasme;
@@ -158,21 +158,21 @@ typedef struct _ueAuthReq
 /* Attach Complete message structure */
 typedef struct _ueEmmAttachComplete
 {
-  U8 ueId;
+  U32 ueId;
   /* TODO */
 }UeEmmAttachComplete;
 
 /* Attach Accept message structure */
 typedef struct _ueEmmAttachAccept 
 {
-   U8 ueId;
+   U32 ueId;
   /* TODO */
 }UeEmmAttachAccept;
 
 /* Auth Response message structure */
 typedef struct _ueEmmAuthRsp
 {
-  U8 ueId;
+  U32 ueId;
   UeAuthPrmRAND authRAND;
   UeAuthPrmAUTHN authAUTHN;
   UeNasKsi nasKasme;
@@ -184,28 +184,28 @@ typedef struct _ueEmmAuthRsp
 /* Security Mode Command message structure */
 typedef struct _ueEmmSecModeCmd
 {
-   U8 ueId;
+   U32 ueId;
   /* TODO */
 }UeEmmSecModeCmd;
 
 /* Security Mode Complete message structure */
 typedef struct _ueEmmSecModeCmp
 {
-  U8 ueId; 
+  U32 ueId; 
   /* TODO */
 }UeEmmSecModeCmp;
 
 /* Detach Request message structure */
 typedef struct _ueEmmDetachReq
 {
-  U8 ueId;
+  U32 ueId;
   /* TODO */
 }UeEmmDetachReq;
 
 /* Detach Accept message structure */
 typedef struct _ueEmmDetachAccept
 {
-  U8 ueId;
+  U32 ueId;
   /* TODO */
 }UeEmmDetachAccept;
 

--- a/TestCntlrApp/src/ueApp/ue_db.c
+++ b/TestCntlrApp/src/ueApp/ue_db.c
@@ -57,8 +57,8 @@ EXTERN UeAppCb gueAppCb;
 EXTERN S16 ueDbmAddUe(UeCb *ueCb);
 EXTERN S16 ueDbmInit(Void);
 EXTERN S16 ueDbmDeInit(Void);
-EXTERN S16 ueDbmDelUe(UeAppCb *, U8 ueId);
-EXTERN S16 ueDbmFetchUe(U8 ueId, PTR *ueCb);
+EXTERN S16 ueDbmDelUe(UeAppCb *, U32 ueId);
+EXTERN S16 ueDbmFetchUe(U32 ueId, PTR *ueCb);
 EXTERN S16 ueDbmDelAllUe(Void);
 EXTERN S16 ueDbmFetchUeWithS_TMSI(UePagingMsg *p_ueMsg, PTR *ueCb);
 
@@ -111,7 +111,7 @@ PUBLIC S16 ueDbmAddUe(UeCb *ueCb)
 
 #ifdef UEHASHLIST
    ret = cmHashListInsert(&(ueAppCb->ueLstCp), (PTR)ueCb,
-         (U8 *)&ueCb->ueId, sizeof(U8));
+         (U8 *)&ueCb->ueId, sizeof(U32));
    if (ret != ROK)
    {
       RETVALUE(ret);
@@ -124,14 +124,14 @@ PUBLIC S16 ueDbmAddUe(UeCb *ueCb)
    RETVALUE(ret);
 }
 
-PUBLIC S16 ueDbmDelUe(UeAppCb *ueAppCb, U8 ueId)
+PUBLIC S16 ueDbmDelUe(UeAppCb *ueAppCb, U32 ueId)
 {
    S16 ret =  ROK;
 #ifdef UEHASHLIST
    UeCb *ueCb = NULLP;
 #else
-   U8 cnt = 0;
-   U8 cnt2 = 0;
+   U32 cnt = 0;
+   U32 cnt2 = 0;
 #endif
    UE_GET_CB(ueAppCb);
 
@@ -180,14 +180,14 @@ PUBLIC S16 ueDbmDelUe(UeAppCb *ueAppCb, U8 ueId)
    RETVALUE(ret);
 }
 
-PUBLIC S16 ueDbmFetchUe(U8 ueId, PTR *ueCb)
+PUBLIC S16 ueDbmFetchUe(U32 ueId, PTR *ueCb)
 {
    UeAppCb *ueAppCb = NULLP;
 #ifdef UEHASHLIST
    S16 ret = ROK;
    UeCb *ueCb1 = (UeCb *)(*ueCb); 
 #else
-   U8 cnt = 0;
+   U32 cnt = 0;
 #endif
    UE_GET_CB(ueAppCb);
 
@@ -216,7 +216,7 @@ PUBLIC S16 ueDbmFetchUeWithS_TMSI(UePagingMsg *p_ueMsg, PTR *ueCb)
 #ifdef UEHASHLIST
    UeCb *ueCbEnt = NULLP;
 #else
-   U8 cnt = 0;
+   U32 cnt = 0;
 #endif
 
    UE_GET_CB(ueAppCb);
@@ -262,7 +262,7 @@ PUBLIC S16 ueDbmDelAllUe(Void)
 #ifdef UEHASHLIST
    UeCb *ueCb = NULLP;
 #else
-   U8 cnt = 0;
+   U32 cnt = 0;
 #endif
    UE_GET_CB(ueAppCb);
 

--- a/TestCntlrApp/src/ueApp/ue_esm.x
+++ b/TestCntlrApp/src/ueApp/ue_esm.x
@@ -513,7 +513,7 @@ typedef struct cmEsmBearResModReq
 /* Esm information request */
 typedef struct cmEsmInfoReq
 {
-   U8 ueId;
+   U32 ueId;
 }CmEsmInfoReq;
 
 /* Esm information response */

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -94,14 +94,14 @@ EXTERN S16 ueUiProcessNbMsg(NbuDlNasMsg *, Pst *);
 PUBLIC S16 ueSendUlNasMsgToNb(NbuUlNasMsg *pUlNasMsg, Pst *pst);
 PUBLIC S16 ueSendUlRrcMsgToNb(NbuUlRrcMsg *pUlRrcMsg, Pst *pst);
 
-EXTERN S16 ueDbmFetchUe(U8 ueId, PTR *ueCb);
+EXTERN S16 ueDbmFetchUe(U32 ueId, PTR *ueCb);
 EXTERN S16 UeLiNbuInitialUeMsg(Pst *pst, NbuInitialUeMsg *msg);
 EXTERN S16 UeLiNbuUlNasMsgDatRsp(Pst *pst, NbuUlNasMsg *msg);
 EXTERN S16 UeLiNbuSendUeIpInfo(Pst *pst,NbuUeIpInfoRsp   *ueInfo);
 EXTERN S16 ueUiProcIpInfoReqMsg(UeCb * p_ueCb, U8 bearerId);
 EXTERN S16 ueAppBldAndSndIpInfoRspToNb(UeCb *ueCb,U8 bearerId, Pst *pst);
 EXTERN S16 UeLiNbuUeIpInfoReq(Pst *pst,NbuUeIpInfoReq  *p_ueMsg);
-EXTERN S16 ueSendUeIpInfoRsp(U8 ueId,U8 bearedId, S8 * ipAddr);
+EXTERN S16 ueSendUeIpInfoRsp(U32 ueId,U8 bearedId, S8 * ipAddr);
 EXTERN Void populateIpInfo(UeCb *ueCb, U8 bearerId, NbuUeIpInfoRsp *);
 
 EXTERN S16 UeLiNbuPagingMsg(Pst *pst, UePagingMsg  *p_ueMsg);
@@ -265,7 +265,7 @@ PUBLIC S16 UeLiNbuUeInactvInd
 )
 {
    S16   ret = RFAILED;
-   U8    ueId = 0;
+   U32    ueId = 0;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -309,7 +309,7 @@ PUBLIC S16 UeLiNbuS1RelInd(Pst *pst,            /* Post structure */
                            NbuS1RelInd *p_ueMsg /* request message */
 ) {
   S16 ret = RFAILED;
-  U8 ueId = 0;
+  U32 ueId = 0;
   UeAppCb *ueAppCb = NULLP;
   UeCb *ueCb = NULLP;
 
@@ -400,7 +400,7 @@ PUBLIC S16 UeLiNbuUeIpInfoReq
 )
 {
    S16   ret = RFAILED;
-   U8    ueId;
+   U32    ueId;
    UeAppCb *ueAppCb=NULLP;
    UeCb *ueCb = NULLP;
    U8 bearerId = 0;
@@ -455,7 +455,7 @@ PUBLIC S16 UeLiNbuNotifyPlmnInfo
 )
 {
    S16   ret = RFAILED;
-   U8    ueId;
+   U32    ueId;
    UeAppCb *ueAppCb=NULLP;
    UeCb *ueCb = NULLP;
    U8 plmn_idx;

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -265,7 +265,7 @@ PUBLIC S16 UeLiNbuUeInactvInd
 )
 {
    S16   ret = RFAILED;
-   U32    ueId = 0;
+   U32   ueId = 0;
    UeAppCb *ueAppCb = NULLP;
    UeCb *ueCb = NULLP;
 
@@ -389,7 +389,7 @@ PUBLIC S16 UeLiNbuUeIpInfoReq
 )
 {
    S16   ret = RFAILED;
-   U32    ueId;
+   U32   ueId;
    UeAppCb *ueAppCb=NULLP;
    UeCb *ueCb = NULLP;
    U8 bearerId = 0;
@@ -444,7 +444,7 @@ PUBLIC S16 UeLiNbuNotifyPlmnInfo
 )
 {
    S16   ret = RFAILED;
-   U32    ueId;
+   U32   ueId;
    UeAppCb *ueAppCb=NULLP;
    UeCb *ueCb = NULLP;
    U8 plmn_idx;


### PR DESCRIPTION
## Title
Added support for attach of more than 256 UEs simultaneously.

## Summary
The current S1APTester was supporting attach of 256 (=2^8) UEs only at one time. This PR increases the attach support for 4294967296 (2^32) UEs simultaneously.

## Test plan
Multi UE attach detach test case was used for testing after incrementing the UE count. Testing is still ongoing. 
