### PR TITLE
Changed code to send Authentication Failure message from test stub

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -841,12 +841,11 @@ typedef struct _ueUetAuthRejInd
    U8 ueId;
 }UeUetAuthRejInd;
 
-typedef struct _ueUetAuthFailure
-{
-   U8 ueId;
-   U8 cause;
-   U8 auts[14];
-}UeUetAuthFailure;
+typedef struct _ueUetAuthFailure {
+  U8 ueId;
+  U8 cause;
+  U8 auts[14];
+} UeUetAuthFailure;
 
 typedef struct _ueUetEmmStatus
 {
@@ -946,7 +945,7 @@ typedef struct _uetMessage
      UeUetPdnDisconnectReq  ueUetPdnDisconnectReq;
      UeUetPdnDisconnectRej  ueUetPdnDisconnectRej;
      UeUetErabSetupFailedTosetup ueErabsFailedToSetup;
-     UeUetAuthFailure         ueUetAuthFailure;
+     UeUetAuthFailure ueUetAuthFailure;
    }msg;
 }UetMessage;
 /* Ue Interface general Structure declerations */

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -205,9 +205,10 @@ typedef enum _ueMsgTypes
    UE_ESM_INFORMATION_RSP_TYPE,
    UE_EPS_DEACTIVATE_BER_REQ,
    UE_EPS_DEACTIVATE_BER_ACC,
-  UE_PDN_DISCONNECT_REQ_TYPE,
-  UE_PDN_DISCONNECT_REJ_TYPE,
-  UE_ERAB_SETUP_REQ_FAILED_FOR_ERABS,
+   UE_PDN_DISCONNECT_REQ_TYPE,
+   UE_PDN_DISCONNECT_REJ_TYPE,
+   UE_ERAB_SETUP_REQ_FAILED_FOR_ERABS,
+   UE_AUTH_FAILURE_TYPE,
 }UeMsgTypes;
 
 typedef struct _ueEmmEpsAtchType
@@ -840,6 +841,13 @@ typedef struct _ueUetAuthRejInd
    U8 ueId;
 }UeUetAuthRejInd;
 
+typedef struct _ueUetAuthFailure
+{
+   U8 ueId;
+   U8 cause;
+   U8 auts[14];
+}UeUetAuthFailure;
+
 typedef struct _ueUetEmmStatus
 {
    U8 ueId;
@@ -938,6 +946,7 @@ typedef struct _uetMessage
      UeUetPdnDisconnectReq  ueUetPdnDisconnectReq;
      UeUetPdnDisconnectRej  ueUetPdnDisconnectRej;
      UeUetErabSetupFailedTosetup ueErabsFailedToSetup;
+     UeUetAuthFailure         ueUetAuthFailure;
    }msg;
 }UetMessage;
 /* Ue Interface general Structure declerations */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -555,22 +555,21 @@ PUBLIC S16 handlAuthResp(ueAuthResp_t *data)
  *   File:  fw_api_int.c
  *
  */
-PUBLIC S16 handlAuthFailure(ueAuthFailure_t *data)
-{
-   FwCb *fwCb = NULLP;
-   UetMessage *uetMsg = NULLP;
-   FW_GET_CB(fwCb);
-   FW_LOG_ENTERFN(fwCb);
+PUBLIC S16 handlAuthFailure(ueAuthFailure_t *data) {
+  FwCb *fwCb = NULLP;
+  UetMessage *uetMsg = NULLP;
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
 
-   FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
-   uetMsg->msgType = UE_AUTH_FAILURE_TYPE;
+  FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+  uetMsg->msgType = UE_AUTH_FAILURE_TYPE;
 
-   uetMsg->msg.ueUetAuthFailure.ueId = data->ue_Id;
-   uetMsg->msg.ueUetAuthFailure.cause = data->cause;
-   cmMemcpy(uetMsg->msg.ueUetAuthFailure.auts, data->auts, TFW_AUTS_LEN);
+  uetMsg->msg.ueUetAuthFailure.ueId = data->ue_Id;
+  uetMsg->msg.ueUetAuthFailure.cause = data->cause;
+  cmMemcpy(uetMsg->msg.ueUetAuthFailure.auts, data->auts, TFW_AUTS_LEN);
 
-   fwSendToUeApp(uetMsg);
-   RETVALUE(ROK);
+  fwSendToUeApp(uetMsg);
+  RETVALUE(ROK);
 }
 
 /*
@@ -2367,20 +2366,17 @@ PUBLIC S16 tfwApi
          handlPdnDisconnectReq((uepdnDisconnectReq_t*)msg);
          break;
       }
-      case UE_AUTH_FAILURE:
-      {
-         FW_LOG_DEBUG(fwCb, "UE_AUTH_FAILURE");
-         if (fwCb->nbState == ENB_IS_UP)
-         {
-            handlAuthFailure((ueAuthFailure_t*)msg);
-         }  
-         else
-         {
-            FW_LOG_ERROR(fwCb, "FAILED TO SEND UE_AUTH_RESP: "\
-                  "ENBAPP IS NOT UP");
-            ret = RFAILED;
-         }
-         break;
+      case UE_AUTH_FAILURE: {
+        FW_LOG_DEBUG(fwCb, "UE_AUTH_FAILURE");
+        if (fwCb->nbState == ENB_IS_UP) {
+          handlAuthFailure((ueAuthFailure_t *)msg);
+        } else {
+          FW_LOG_ERROR(fwCb,
+                       "FAILED TO SEND UE_AUTH_RESP: "
+                       "ENBAPP IS NOT UP");
+          ret = RFAILED;
+        }
+        break;
       }
 
      default:

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -543,7 +543,37 @@ PUBLIC S16 handlAuthResp(ueAuthResp_t *data)
 }
 
 /*
+ *   Fun:   handlAuthFailure
  *
+ *   Desc:  This function is used to handle Auth Failure
+ *          from Test Controller
+ *
+ *   Ret:   None
+ *
+ *   Notes: None
+ *
+ *   File:  fw_api_int.c
+ *
+ */
+PUBLIC S16 handlAuthFailure(ueAuthFailure_t *data)
+{
+   FwCb *fwCb = NULLP;
+   UetMessage *uetMsg = NULLP;
+   FW_GET_CB(fwCb);
+   FW_LOG_ENTERFN(fwCb);
+
+   FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+   uetMsg->msgType = UE_AUTH_FAILURE_TYPE;
+
+   uetMsg->msg.ueUetAuthFailure.ueId = data->ue_Id;
+   uetMsg->msg.ueUetAuthFailure.cause = data->cause;
+   cmMemcpy(uetMsg->msg.ueUetAuthFailure.auts, data->auts, TFW_AUTS_LEN);
+
+   fwSendToUeApp(uetMsg);
+   RETVALUE(ROK);
+}
+
+/*
  *   Fun:   handlRadCapUpd
  *
  *   Desc:  This function is used to handle UE Radio Capability Update
@@ -2335,6 +2365,21 @@ PUBLIC S16 tfwApi
       {
          FW_LOG_DEBUG(fwCb, "UE_PDN_DISCONNECT_REQ");
          handlPdnDisconnectReq((uepdnDisconnectReq_t*)msg);
+         break;
+      }
+      case UE_AUTH_FAILURE:
+      {
+         FW_LOG_DEBUG(fwCb, "UE_AUTH_FAILURE");
+         if (fwCb->nbState == ENB_IS_UP)
+         {
+            handlAuthFailure((ueAuthFailure_t*)msg);
+         }  
+         else
+         {
+            FW_LOG_ERROR(fwCb, "FAILED TO SEND UE_AUTH_RESP: "\
+                  "ENBAPP IS NOT UP");
+            ret = RFAILED;
+         }
          break;
       }
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -100,6 +100,8 @@ extern "C" {
 #define UE_ESM_IP_SEC_SIZE 4
 #define UE_ESM_IPV6_FLOW_LABEL_SIZE  3
 #define UE_ESM_TFT_MAX_PARAM_BUF   10
+// Authentication failure param AUTS length
+#define TFW_AUTS_LEN     14
 #define MAX_FAILED_ERABS 11
 #ifdef TFW_STUB /* definitions only required by test controller */
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -101,7 +101,7 @@ extern "C" {
 #define UE_ESM_IPV6_FLOW_LABEL_SIZE  3
 #define UE_ESM_TFT_MAX_PARAM_BUF   10
 // Authentication failure param AUTS length
-#define TFW_AUTS_LEN     14
+#define TFW_AUTS_LEN 14
 #define MAX_FAILED_ERABS 11
 #ifdef TFW_STUB /* definitions only required by test controller */
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -116,10 +116,11 @@ typedef enum {
    PATH_SW_REQ_ACK,
    ENB_CONFIGURATION_TRANSFER,
    MME_CONFIGURATION_TRANSFER = 81,
-  UE_PDN_DISCONNECT_REQ,
-  UE_PDN_DISCONNECT_TIMEOUT_IND,
-  UE_PDN_DISCONNECT_REJ,
-  UE_FW_ERAB_SETUP_REQ_FAILED_FOR_ERABS
+   UE_PDN_DISCONNECT_REQ,
+   UE_PDN_DISCONNECT_TIMEOUT_IND,
+   UE_PDN_DISCONNECT_REJ,
+   UE_FW_ERAB_SETUP_REQ_FAILED_FOR_ERABS,
+   UE_AUTH_FAILURE 
 }tfwCmd;
 
 typedef enum
@@ -1492,6 +1493,13 @@ typedef struct UeAuthRejInd
 {
    U8 ue_Id;
 }ueAuthRejInd_t;
+
+typedef struct UeAuthFailure
+{
+   U8 ue_Id;
+   U8 cause;
+   U8 auts[TFW_AUTS_LEN];
+}ueAuthFailure_t;
 
 typedef struct UeEmmStatus
 {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -120,7 +120,7 @@ typedef enum {
    UE_PDN_DISCONNECT_TIMEOUT_IND,
    UE_PDN_DISCONNECT_REJ,
    UE_FW_ERAB_SETUP_REQ_FAILED_FOR_ERABS,
-   UE_AUTH_FAILURE 
+   UE_AUTH_FAILURE
 }tfwCmd;
 
 typedef enum
@@ -1494,12 +1494,11 @@ typedef struct UeAuthRejInd
    U8 ue_Id;
 }ueAuthRejInd_t;
 
-typedef struct UeAuthFailure
-{
-   U8 ue_Id;
-   U8 cause;
-   U8 auts[TFW_AUTS_LEN];
-}ueAuthFailure_t;
+typedef struct UeAuthFailure {
+  U8 ue_Id;
+  U8 cause;
+  U8 auts[TFW_AUTS_LEN];
+} ueAuthFailure_t;
 
 typedef struct UeEmmStatus
 {

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -814,39 +814,37 @@ PRIVATE S16 ueProcUeAuthResp(UetMessage *tfwMsg, Pst *pst)
  *       File:  ue_app.c
  *
  */
-PRIVATE S16 ueProcUeAuthFailure(UetMessage *tfwMsg, Pst *pst)
-{
-   S16 ret = ROK;
-   U16 ueId;
+PRIVATE S16 ueProcUeAuthFailure(UetMessage *tfwMsg, Pst *pst) {
+  S16 ret = ROK;
+  U16 ueId;
 
-   UeAppCb *ueAppCb = NULLP;
-   UeCb *ueCb = NULLP;
-   UE_GET_CB(ueAppCb);
+  UeAppCb *ueAppCb = NULLP;
+  UeCb *ueCb = NULLP;
+  UE_GET_CB(ueAppCb);
 
-   UE_LOG_ENTERFN(ueAppCb);
-   ueId = tfwMsg->msg.ueUetAuthFailure.ueId;
+  UE_LOG_ENTERFN(ueAppCb);
+  ueId = tfwMsg->msg.ueUetAuthFailure.ueId;
 
-   /* Fetching the UeCb */
-   ret = ueDbmFetchUe(ueId, (PTR*)&ueCb);
-   if (ret != ROK)
-   {
-      UE_LOG_ERROR(ueAppCb, "UeCb List NULL ueId = %d", ueId);
-      RETVALUE(ret);
-   }
-   ueCb->authFlr.cause.cause = tfwMsg->msg.ueUetAuthFailure.cause;
-   UE_LOG_DEBUG(ueAppCb, "Authentication Failed, Failure cause is %d",
-         ueCb->authFlr.cause.cause);
-   ueCb->authFlr.cause.pres = TRUE;
-   ueCb->authFlr.failrPrm.pres = TRUE;
-   ueCb->authFlr.failrPrm.len = UE_AUTS_SIZE;
-   ret = ueAppSndAuthFailure(ueCb);
-   if (ret != ROK)
-   {
-      UE_LOG_ERROR(ueAppCb, "Sending Authentication Failure "\
-            "message to ENB failed");
-   }
-   UE_LOG_EXITFN(ueAppCb, ret);
-   RETVALUE(ret);
+  /* Fetching the UeCb */
+  ret = ueDbmFetchUe(ueId, (PTR *)&ueCb);
+  if (ret != ROK) {
+    UE_LOG_ERROR(ueAppCb, "UeCb List NULL ueId = %d", ueId);
+    RETVALUE(ret);
+  }
+  ueCb->authFlr.cause.cause = tfwMsg->msg.ueUetAuthFailure.cause;
+  UE_LOG_DEBUG(ueAppCb, "Authentication Failed, Failure cause is %d",
+               ueCb->authFlr.cause.cause);
+  ueCb->authFlr.cause.pres = TRUE;
+  ueCb->authFlr.failrPrm.pres = TRUE;
+  ueCb->authFlr.failrPrm.len = UE_AUTS_SIZE;
+  ret = ueAppSndAuthFailure(ueCb);
+  if (ret != ROK) {
+    UE_LOG_ERROR(ueAppCb,
+                 "Sending Authentication Failure "
+                 "message to ENB failed");
+  }
+  UE_LOG_EXITFN(ueAppCb, ret);
+  RETVALUE(ret);
 }
 /*
  *
@@ -5520,12 +5518,12 @@ PUBLIC S16 ueUiProcessTfwMsg(UetMessage *p_ueMsg, Pst *pst)
          ret = ueProcUePdnDisconnectReq(p_ueMsg, pst);
          break;
       }
-      case UE_AUTH_FAILURE_TYPE:
-      {
-         UE_LOG_DEBUG(ueAppCb, "RECIEVED UE AUTHENTICATION FAILURE "\
-               "MESSAGE FROM TFWAPP");
-         ret = ueProcUeAuthFailure(p_ueMsg, pst);
-         break;
+      case UE_AUTH_FAILURE_TYPE: {
+        UE_LOG_DEBUG(ueAppCb,
+                     "RECIEVED UE AUTHENTICATION FAILURE "
+                     "MESSAGE FROM TFWAPP");
+        ret = ueProcUeAuthFailure(p_ueMsg, pst);
+        break;
       }
       default:
       {

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -803,6 +803,53 @@ PRIVATE S16 ueProcUeAuthResp(UetMessage *tfwMsg, Pst *pst)
 
 /*
  *
+ *       Fun: ueProcUeAuthFailure
+ *
+ *       Desc:
+ *
+ *       Ret:  ROK - ok; RFAILED - failed
+ *
+ *       Notes: none
+ *
+ *       File:  ue_app.c
+ *
+ */
+PRIVATE S16 ueProcUeAuthFailure(UetMessage *tfwMsg, Pst *pst)
+{
+   S16 ret = ROK;
+   U16 ueId;
+
+   UeAppCb *ueAppCb = NULLP;
+   UeCb *ueCb = NULLP;
+   UE_GET_CB(ueAppCb);
+
+   UE_LOG_ENTERFN(ueAppCb);
+   ueId = tfwMsg->msg.ueUetAuthFailure.ueId;
+
+   /* Fetching the UeCb */
+   ret = ueDbmFetchUe(ueId, (PTR*)&ueCb);
+   if (ret != ROK)
+   {
+      UE_LOG_ERROR(ueAppCb, "UeCb List NULL ueId = %d", ueId);
+      RETVALUE(ret);
+   }
+   ueCb->authFlr.cause.cause = tfwMsg->msg.ueUetAuthFailure.cause;
+   UE_LOG_DEBUG(ueAppCb, "Authentication Failed, Failure cause is %d",
+         ueCb->authFlr.cause.cause);
+   ueCb->authFlr.cause.pres = TRUE;
+   ueCb->authFlr.failrPrm.pres = TRUE;
+   ueCb->authFlr.failrPrm.len = UE_AUTS_SIZE;
+   ret = ueAppSndAuthFailure(ueCb);
+   if (ret != ROK)
+   {
+      UE_LOG_ERROR(ueAppCb, "Sending Authentication Failure "\
+            "message to ENB failed");
+   }
+   UE_LOG_EXITFN(ueAppCb, ret);
+   RETVALUE(ret);
+}
+/*
+ *
  *       Fun: ueAppEdmDecode
  *
  *       Desc: This function decodes NAS message received from eNodeB.
@@ -5473,7 +5520,13 @@ PUBLIC S16 ueUiProcessTfwMsg(UetMessage *p_ueMsg, Pst *pst)
          ret = ueProcUePdnDisconnectReq(p_ueMsg, pst);
          break;
       }
-
+      case UE_AUTH_FAILURE_TYPE:
+      {
+         UE_LOG_DEBUG(ueAppCb, "RECIEVED UE AUTHENTICATION FAILURE "\
+               "MESSAGE FROM TFWAPP");
+         ret = ueProcUeAuthFailure(p_ueMsg, pst);
+         break;
+      }
       default:
       {
          UE_LOG_ERROR(ueAppCb, "Recieved Invalid message of type: %d",


### PR DESCRIPTION
Title
Support to send Authentication Failure message from s1ap simulator

Summary
Support to handle Authentication Failure message from python test script and sends message from s1aptester(UE) to MME.
-Background:
As part of Magma issue PR#1022 identified that MME crashes when UE Authentication failure message received at MME. To simulate the scenario, added python test script at magma AGW and observed that there was no support to send the Authentication failure message from S1APTester. Hence added support to handle authentication failure message from python test script and sending to MME.

Test plan
Build sanity
Newly added tests - test_attach_auth_failure.py
