### PR TITLE
Revert "resolved compilation error of Test Controller Stub"

### DIFF
--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -1442,7 +1442,7 @@ typedef struct _resetReq
    {
       CompleteReset completeRst;
       PartialReset partialRst;
-   }u;
+   }r;
 }ResetReq;
 
 typedef struct _fwNbS1ResetAck

--- a/TestCntlrStub/src/ts_utls.c
+++ b/TestCntlrStub/src/ts_utls.c
@@ -229,7 +229,6 @@ int TC_msg_recv(int msgid, int timeout)
    FwErabRelCmd_t     *tfwErabRelCmdInfo = NULL;
    ueNasNonDelRsp_t   *tfwNasNonDelRsp = NULL;
    FwNbIntCtxSetupInd_t *tfwIntCtxSetupInd = NULL;
-   uePdnDisconnFail_t *tfwPdnDisconnFail = NULL;
 
    printf("[Stub] %s:%s():%d: Entering\n", __FILE__, __FUNCTION__, __LINE__);
    printf("[Stub] TC_msg_recv(): msgid=%d\n", msgid);


### PR DESCRIPTION
Reverts facebookexperimental/S1APTester#22

The code compilation is failing with these changes, so reverting this commit.