### PR TITLE
[Code_Compile] [Warning_Fix] Fixed some compilation warnings related to FUNCTION macro

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_log.h
+++ b/TestCntlrApp/src/enbApp/nb_log.h
@@ -31,7 +31,7 @@ do {\
    if(((_nbCb)->init.dbgMask >= LNB_LOGLVL_TRACE))\
    {\
       logLevN(LNB_LOGLVL_TRACE, NB_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Entering %s()", __FUNCTION__);\
+            "Entering %s()", __func__);\
    }\
 } while(0)
 
@@ -40,7 +40,7 @@ do {\
    if(((_nbCb)->init.dbgMask >= LNB_LOGLVL_TRACE))\
    {\
       logLevN(LNB_LOGLVL_TRACE, NB_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s(), [Return %d]", __FUNCTION__, _ret);\
+            "Exiting %s(), [Return %d]", __func__, _ret);\
    }\
    return _ret;\
 } while(0)
@@ -50,7 +50,7 @@ do {\
    if((_nbCb)->init.dbgMask >= LNB_LOGLVL_TRACE)\
    {\
       logLevN(LNB_LOGLVL_TRACE, NB_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s()", __FUNCTION__);\
+            "Exiting %s()", __func__);\
    }\
    return;\
 } while(0)

--- a/TestCntlrApp/src/sm/fw_sm_log.h
+++ b/TestCntlrApp/src/sm/fw_sm_log.h
@@ -54,7 +54,7 @@ do {\
    if(((_smCb).init.dbgMask >= LSM_LOGLVL_TRACE))\
    {\
       logLevN(LSM_LOGLVL_TRACE, FW_SM_MODULE_NAME, __FILE__,__LINE__,\
-            "Entering %s()", __FUNCTION__);\
+            "Entering %s()", __func__);\
    }\
 } while(0)
 
@@ -64,7 +64,7 @@ do {\
    if(((_smCb).init.dbgMask >= LSM_LOGLVL_TRACE))\
    {\
       logLevN(LSM_LOGLVL_TRACE, FW_SM_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s(), [Return %d]", __FUNCTION__, _ret);\
+            "Exiting %s(), [Return %d]", __func__, _ret);\
    }\
    return _ret;\
 } while(0)
@@ -75,7 +75,7 @@ do {\
    if((_smCb).init.dbgMask >= LSM_LOGLVL_TRACE)\
    {\
       logLevN(LSM_LOGLVL_TRACE, FW_SM_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s()", __FUNCTION__);\
+            "Exiting %s()", __func__);\
    }\
    return;\
 } while(0)

--- a/TestCntlrApp/src/tfwApp/fw_log.h
+++ b/TestCntlrApp/src/tfwApp/fw_log.h
@@ -15,7 +15,7 @@ do {\
    if(((_fwCb)->init.dbgMask >= LFW_LOGLVL_TRACE))\
    {\
       logLevN(LFW_LOGLVL_TRACE, FW_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Entering %s()", __FUNCTION__);\
+            "Entering %s()", __func__);\
    }\
 } while(0)
 
@@ -24,7 +24,7 @@ do {\
    if(((_fwCb)->init.dbgMask >= LFW_LOGLVL_TRACE))\
    {\
       logLevN(LFW_LOGLVL_TRACE, FW_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s(), [Return %d]", __FUNCTION__, _ret);\
+            "Exiting %s(), [Return %d]", __func__, _ret);\
    }\
    return _ret;\
 } while(0)
@@ -34,7 +34,7 @@ do {\
    if((_fwCb)->init.dbgMask >= LFW_LOGLVL_TRACE)\
    {\
       logLevN(LFW_LOGLVL_TRACE, FW_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s()", __FUNCTION__);\
+            "Exiting %s()", __func__);\
    }\
    return;\
 } while(0)

--- a/TestCntlrApp/src/ueApp/ue_log.h
+++ b/TestCntlrApp/src/ueApp/ue_log.h
@@ -15,7 +15,7 @@ do {\
    if(((_ueCb)->init.dbgMask >= LUE_LOGLVL_TRACE))\
    {\
       logLevN(LUE_LOGLVL_TRACE, UE_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Entering %s()", __FUNCTION__);\
+            "Entering %s()", __func__);\
    }\
 } while(0)
 
@@ -24,7 +24,7 @@ do {\
    if(((_ueCb)->init.dbgMask >= LUE_LOGLVL_TRACE))\
    {\
       logLevN(LUE_LOGLVL_TRACE, UE_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s(), [Return %d]", __FUNCTION__, _ret);\
+            "Exiting %s(), [Return %d]", __func__, _ret);\
    }\
    return _ret;\
 } while(0)
@@ -34,7 +34,7 @@ do {\
    if((_ueCb)->init.dbgMask >= LUE_LOGLVL_TRACE)\
    {\
       logLevN(LUE_LOGLVL_TRACE, UE_APP_MODULE_NAME, __FILE__,__LINE__,\
-            "Exiting %s()", __FUNCTION__);\
+            "Exiting %s()", __func__);\
    }\
    return;\
 } while(0)


### PR DESCRIPTION
## Title
[Code_Compile] [Warning_Fix] Fixed some compilation warnings related to FUNCTION macro

## Summary
There are too many warnings during S1APTester code compilation which creates problem while debugging compilation errors. This PR removes around 615 warnings related to deprecated macro __FUNCTION__, which is now replaced with __func__.

## Test plan
Verified Sanity using Magma EPC
