### PR TITLE
Provided fix for test case, test_paging_request.py

### DIFF
--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -4009,6 +4009,13 @@ PRIVATE S16 ueProcUeDetachRequest
       UE_LOG_ERROR(ueAppCb, "Sending Detach Request message failed");
       UE_LOG_EXITFN(ueAppCb, ret);
    }
+   /* Free all the DRBs allocated for this ueId */
+   UE_LOG_DEBUG(ueAppCb, "Freeing all the DRBs allocated for ueId: %d", ueId);
+   for (U8 idx = 0; idx < UE_APP_MAX_DRBS; idx++) {
+     cmMemset((U8 *)&(ueCb->ueRabCb[idx]), 0, sizeof(ueCb->ueRabCb[idx]));
+     ueCb->drbs[idx] = UE_APP_DRB_AVAILABLE;
+     ueCb->numRabs--;
+   }
 
    UE_LOG_EXITFN(ueAppCb, ret);
 } /* ueProcUeDetachRequest */
@@ -7863,9 +7870,10 @@ PUBLIC S16 ueUiProcErabsRelInfoMsg(Pst *pst, NbuErabsRelInfo *pNbuErabsRelInfo)
 
    UE_LOG_EXITFN(ueAppCb, ret);
 }
+
 PUBLIC S16 ueUiProcErabsInfoMsg(Pst *pst, NbuErabsInfo *pNbuErabsInfo)
 {
-   int i = 0;
+   int idx = 0;
    S16 ret = ROK;
    U16 ueId;
    UeAppCb *ueAppCb = NULLP;
@@ -7895,60 +7903,61 @@ PUBLIC S16 ueUiProcErabsInfoMsg(Pst *pst, NbuErabsInfo *pNbuErabsInfo)
      ret = ueSendUeRadCapInd(ueCb);
    }
    if (pNbuErabsInfo->erabInfo) {
-     for (i = 0; i < pNbuErabsInfo->erabInfo->numOfErab; i++) {
-       nasPdu = &pNbuErabsInfo->erabInfo->rabCbs[i].nasPdu;
-       /* Decoding the PDU */
-       ret = ueAppEdmDecode(nasPdu, &ueEvnt);
-       if (ret != ROK) {
-         UE_LOG_ERROR(ueAppCb, "NAS pdu decoding failed");
-         ret = RFAILED;
-         RETVALUE(ret);
-       }
-       if (ueEvnt == NULLP) {
-         UE_LOG_ERROR(ueAppCb, "ueEvnt is NULL");
-         RETVALUE(RFAILED);
-       }
-       if ((CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC == ueEvnt->secHT) ||
-           (CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC_NEW_SEC_CTXT == ueEvnt->secHT)) {
-         srcMsg.val = nasPdu->val;
-         srcMsg.len = nasPdu->len;
-         ret = ueAppVldDwnlnkSec(&ueCb->secCtxt, &srcMsg, &dstMsg);
-         if (ROK != ret) {
-           UE_LOG_ERROR(ueAppCb, "Uplink security validation failed \n");
-           /*Ignore the event*/
-           ueEvnt->pdu = NULLP;
-           CM_FREE_NASEVNT(&ueEvnt);
-           RETVALUE(RFAILED);
-         }
-
-         cmMemcpy((U8 *)&nasMsg, (CONSTANT U8 *)nasPdu,
-                  sizeof(NhuDedicatedInfoNAS));
-         nasMsg.val = dstMsg.val;
-         nasMsg.len = dstMsg.len;
-         ret = ueAppEdmDecode(&nasMsg, &ueEvnt);
-         if (ROK != ret) {
-           UE_LOG_ERROR(ueAppCb, "Uplink NAS message decode failed\n");
-           RETVALUE(ret); /* Should we send Failure back to eNB */
+     for (idx = 0; idx < pNbuErabsInfo->erabInfo->numOfErab; idx++) {
+       nasPdu = &pNbuErabsInfo->erabInfo->rabCbs[idx].nasPdu;
+       if (nasPdu->val) {
+         /* Decoding the PDU */
+         ret = ueAppEdmDecode(nasPdu, &ueEvnt);
+         if (ret != ROK) {
+           UE_LOG_ERROR(ueAppCb, "NAS pdu decoding failed");
+           RETVALUE(ret);
          }
          if (ueEvnt == NULLP) {
            UE_LOG_ERROR(ueAppCb, "ueEvnt is NULL");
            RETVALUE(RFAILED);
          }
-       }
+         if ((CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC == ueEvnt->secHT) ||
+             (CM_NAS_SEC_HDR_TYPE_INT_PRTD_ENC_NEW_SEC_CTXT == ueEvnt->secHT)) {
+           srcMsg.val = nasPdu->val;
+           srcMsg.len = nasPdu->len;
+           ret = ueAppVldDwnlnkSec(&ueCb->secCtxt, &srcMsg, &dstMsg);
+           if (ROK != ret) {
+             UE_LOG_ERROR(ueAppCb, "Uplink security validation failed \n");
+             /*Ignore the event*/
+             ueEvnt->pdu = NULLP;
+             CM_FREE_NASEVNT(&ueEvnt);
+             RETVALUE(RFAILED);
+           }
 
-       /* Handle the incoming events */
-       if (ueEvnt->protDisc == CM_EMM_PD) {
-         ret = ueAppEmmHdlIncUeEvnt(ueEvnt, ueCb);
-       } else if (ueEvnt->protDisc == CM_ESM_PD) {
-         ret = ueAppEsmHdlIncUeEvnt(ueEvnt, ueCb, FALSE);
-       }
-       if (ret != ROK) {
-         UE_LOG_ERROR(ueAppCb, "Handling Initial UE Event failed");
-         ret = RFAILED;
-       }
+           cmMemcpy((U8 *)&nasMsg, (CONSTANT U8 *)nasPdu,
+                    sizeof(NhuDedicatedInfoNAS));
+           nasMsg.val = dstMsg.val;
+           nasMsg.len = dstMsg.len;
+           ret = ueAppEdmDecode(&nasMsg, &ueEvnt);
+           if (ROK != ret) {
+             UE_LOG_ERROR(ueAppCb, "Uplink NAS message decode failed\n");
+             RETVALUE(ret); /* Should we send Failure back to eNB */
+           }
+           if (ueEvnt == NULLP) {
+             UE_LOG_ERROR(ueAppCb, "ueEvnt is NULL");
+             RETVALUE(RFAILED);
+           }
+         }
 
-       ueFree((U8 *)nasPdu->val, nasPdu->len * sizeof(U8));
-       CM_FREE_NASEVNT(&ueEvnt);
+         /* Handle the incoming events */
+         if (ueEvnt->protDisc == CM_EMM_PD) {
+           ret = ueAppEmmHdlIncUeEvnt(ueEvnt, ueCb);
+         } else if (ueEvnt->protDisc == CM_ESM_PD) {
+           ret = ueAppEsmHdlIncUeEvnt(ueEvnt, ueCb, FALSE);
+         }
+         if (ret != ROK) {
+           UE_LOG_ERROR(ueAppCb, "Handling Initial UE Event failed");
+           ret = RFAILED;
+         }
+
+         ueFree((U8 *)nasPdu->val, nasPdu->len * sizeof(U8));
+         CM_FREE_NASEVNT(&ueEvnt);
+       }
      }
    }
    if (pNbuErabsInfo->failedErabList &&

--- a/TestCntlrApp/src/ueApp/ue_li.c
+++ b/TestCntlrApp/src/ueApp/ue_li.c
@@ -8,19 +8,19 @@
 
 /**********************************************************************
 
- 
-    Name:  LTE S1SIM - UE Application Module 
- 
+
+    Name:  LTE S1SIM - UE Application Module
+
     Type:  C ource file
- 
+
     Desc:  C source code for APIs towards lower interface.
- 
+
     File:  ue_li.c
- 
-    Sid:   
- 
-    Prg:   
- 
+
+    Sid:
+
+    Prg:
+
 **********************************************************************/
 
 #include <stdbool.h>
@@ -237,7 +237,7 @@ PUBLIC S16 UeLiNbuPagingMsg
    {
       /* if the message is valid, then de-allocate the
        * memory to avoid memory leak
-       */      
+       */
       if(p_ueMsg)
       {
          if ((ret = ueFree((U8*)p_ueMsg, sizeof(UePagingMsg))) != ROK )
@@ -328,17 +328,6 @@ PUBLIC S16 UeLiNbuS1RelInd(Pst *pst,            /* Post structure */
     UE_LOG_ERROR(ueAppCb, "UeCb doesn't exist for ueId = %d", ueId);
     RETVALUE(ret);
   }
-
-  /* Free all the DRBs allocated for this ueId */
-  UE_LOG_DEBUG(ueAppCb, "Freeing all the DRBs allocated for ueId: %d", ueId);
-  for (U8 idx = 0; idx < UE_APP_MAX_DRBS; idx++) {
-    if (ueCb->drbs[idx] == UE_APP_DRB_INUSE) {
-      cmMemset((U8 *)&(ueCb->ueRabCb[idx]), 0, sizeof(ueCb->ueRabCb[idx]));
-      ueCb->drbs[idx] = UE_APP_DRB_AVAILABLE;
-      ueCb->numRabs--;
-    }
-  }
-
   /* change the ue state to idle */
   ueCb->ecmCb.state = UE_ECM_IDLE;
 
@@ -347,7 +336,7 @@ PUBLIC S16 UeLiNbuS1RelInd(Pst *pst,            /* Post structure */
 
 PUBLIC S16 ueSendInitialUeMsg(NbuInitialUeMsg *pInitialUeMsg, Pst *pst)
 {
-   S16 ret = ROK; 
+   S16 ret = ROK;
    UeAppCb *ueAppCb;
 
    UE_GET_CB(ueAppCb);
@@ -355,7 +344,7 @@ PUBLIC S16 ueSendInitialUeMsg(NbuInitialUeMsg *pInitialUeMsg, Pst *pst)
 
    UE_LOG_DEBUG(ueAppCb, "Sending Initial UE message to EnodeB APP");
 
-   ret = UeLiNbuInitialUeMsg(pst, pInitialUeMsg); 
+   ret = UeLiNbuInitialUeMsg(pst, pInitialUeMsg);
    if (ret != ROK)
    {
       UE_LOG_ERROR(ueAppCb, "Sending Dat Req to NB failed");
@@ -364,7 +353,7 @@ PUBLIC S16 ueSendInitialUeMsg(NbuInitialUeMsg *pInitialUeMsg, Pst *pst)
 }
 PUBLIC S16 ueSendErabRelInd(NbuErabRelIndList *pErabRel, Pst *pst)
 {
-   S16 ret = ROK; 
+   S16 ret = ROK;
    UeAppCb *ueAppCb;
 
    UE_GET_CB(ueAppCb);
@@ -372,7 +361,7 @@ PUBLIC S16 ueSendErabRelInd(NbuErabRelIndList *pErabRel, Pst *pst)
 
    UE_LOG_DEBUG(ueAppCb, "Sending Erab Release Indication to EnodeB APP");
 
-   ret = UeLiNbuErabRelInd(pst, pErabRel); 
+   ret = UeLiNbuErabRelInd(pst, pErabRel);
    if (ret != ROK)
    {
       UE_LOG_ERROR(ueAppCb, "Sending Dat Req to NB failed");
@@ -388,7 +377,7 @@ PUBLIC S16 ueSendUlNasMsgToNb(NbuUlNasMsg *pUlNasMsg, Pst *pst)
    UE_LOG_ENTERFN(ueAppCb);
 
    UE_LOG_DEBUG(ueAppCb, "Sending UE UL NAS message to EnodeB APP");
-   ret = UeLiNbuUlNasMsgDatRsp(pst, pUlNasMsg); 
+   ret = UeLiNbuUlNasMsgDatRsp(pst, pUlNasMsg);
 
    RETVALUE(ret);
 }
@@ -443,7 +432,7 @@ PUBLIC S16 ueSendUlRrcMsgToNb(NbuUlRrcMsg *pUlRrcMsg, Pst *pst)
    UE_LOG_ENTERFN(ueAppCb);
 
    UE_LOG_DEBUG(ueAppCb, "Sending UE UL RRC message to EnodeB APP");
-   ret = UeLiNbuUlRrcMsgDatRsp(pst, pUlRrcMsg); 
+   ret = UeLiNbuUlRrcMsgDatRsp(pst, pUlRrcMsg);
 
    RETVALUE(ret);
 }


### PR DESCRIPTION
## Provided fix for test case, test_paging_Request.py
When UE's ECM state changes from Idle to connected,  s1ap tester was not forwarding UL data, due to which test_paging_request.py testcase was failing.

## Summary
When UE's ECM state changes from Idle to connected,  s1ap tester was not forwarding UL data,  Because when UE was moved to Idle state, UE's DRB contexts were deleted which shouldn't have been deleted. DRBs should be deleted only when UE processes through detach procedure
So as part of this PR, UE's DRB contexts are not deleted when goes to Idle mode, instead DRB contexts are deleted as part of detach procedure
## Test plan
- Sanity test suite is working fine
- Existing relevant tests are test_paging_request.py, downlink and uplink data testcases
