### PR TITLE
Added code to provide enb_ue_s1ap_id and mme_ue_s1ap_id from test script

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -882,8 +882,9 @@ PRIVATE S16 nbBldResetReq
             resetIe->value.u.sztUE_assocLogS1_ConItem.mME_UE_S1AP_ID.pres =
 	           NOTPRSNT;
 	 }
-         nbFillTknU32(&(resetIe->value.u.sztUE_assocLogS1_ConItem.\
-                  eNB_UE_S1AP_ID), resetMsgInfo->enbUeS1apIdLst[cnt] && 0xFF);
+         nbFillTknU32(
+             &(resetIe->value.u.sztUE_assocLogS1_ConItem.eNB_UE_S1AP_ID),
+             resetMsgInfo->enbUeS1apIdLst[cnt] & 0xFF);
 
          resetIe->value.u.sztUE_assocLogS1_ConItem.iE_Extns.\
             noComp.pres = NOTPRSNT;
@@ -1296,8 +1297,7 @@ PUBLIC S16 nbProcPagingMsg
  *       RFAILED : not able to process the ERAB Release Cmd message due to
  *       memory lack.
  */
-PUBLIC S16 nbProcErabRelCmd(S1apPdu *s1apErabRlsCmd) 
-{
+PUBLIC S16 nbProcErabRelCmd(S1apPdu *s1apErabRlsCmd) {
   S16 retVal = ROK;
   U16 numComp = 0;
   U16 cnt = 0;

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -192,6 +192,13 @@ typedef struct _nbConfigCfm
  CfgFailCause cause;
 }NbConfigCfm;
 
+typedef struct _NbUeS1apIdPair
+{
+   U8 ueId;
+   U32 enbUeS1apId;
+   U32 mmeUeS1apId;
+} NbUeS1apIdPair;
+
 typedef struct _nbRelCause
 {
    U8 causeType;
@@ -218,7 +225,7 @@ typedef struct _nbCompleteReset
 typedef struct _mnPartialReset
 {
    U16 numOfConn;
-   U8 *ueIdLst;
+   NbUeS1apIdPair *ueS1apIdPairList;
 }NbPartialReset;
 
 typedef struct _nbCause

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -1568,12 +1568,14 @@ PUBLIC S16 handleResetRequest(ResetReq *data)
    else if(msgReq->t.resetReq.rstType == NB_PARTIAL_RESET)
    {
       msgReq->t.resetReq.u.partialRst.numOfConn = data->r.partialRst.numOfConn;
-      FW_ALLOC_MEM(fwCb, &msgReq->t.resetReq.u.partialRst.ueIdLst,
-            msgReq->t.resetReq.u.partialRst.numOfConn);
+      FW_ALLOC_MEM(
+          fwCb, &msgReq->t.resetReq.u.partialRst.ueS1apIdPairList,
+          sizeof(NbUeS1apIdPair) * msgReq->t.resetReq.u.partialRst.numOfConn);
 
-      cmMemcpy(msgReq->t.resetReq.u.partialRst.ueIdLst,
-            data->r.partialRst.ueIdLst,
-            msgReq->t.resetReq.u.partialRst.numOfConn);
+      cmMemcpy(
+          msgReq->t.resetReq.u.partialRst.ueS1apIdPairList,
+          data->r.partialRst.ueS1apIdPairList,
+          sizeof(NbUeS1apIdPair) * msgReq->t.resetReq.u.partialRst.numOfConn);
    }
    else
    {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -1410,6 +1410,13 @@ typedef struct ueRadCapUpd
    radio_Cpblty radioCap_pr;
 }ueRadCapUpd_t;
 
+typedef struct _UeS1apIdPair
+{
+   U8 ueId;
+   U32 enbUeS1apId;
+   U32 mmeUeS1apId;
+} UeS1apIdPair;
+
 typedef enum
 {
    COMPLETE_RESET = 0,
@@ -1425,7 +1432,7 @@ typedef struct _CompleteReset
 typedef struct _PartialReset
 {
    U16 numOfConn;
-   U8 *ueIdLst;
+   UeS1apIdPair *ueS1apIdPairList;
 }PartialReset;
 
 typedef struct _cause


### PR DESCRIPTION
Signed-off-by: rashmi <rashmi.sarwad@radisys.com>

## Title: Added code to provide enb_ue_s1ap_id and mme_ue_s1ap_id from test script while testing Partial Reset message

## Summary
Full description of the PR.
- Added provision to send enb_ue_s1ap_id and mme_ue_s1ap_id from test script while testing Partial Reset message. So that we can simulate the scenario to send Partial Reset message with unknown s1ap_ids from test script.

## Test plan
- Sanity test suite is working fine
- Added new test-case, test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
