### PR TITLE
Added code to drop E-Rab Setup Request message

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -56,6 +56,7 @@ PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail);
 EXTERN S16 nbIfmDamTnlCreatReq(NbDamTnlInfo*);
 EXTERN S16 nbIfmDamUeRelReq(U32, U8);
 EXTERN S16 nbAppRouteInit(U32 selfIp, S8*);
+PUBLIC S16 NbHandleDropErabSetupReq(NbDropErabSetupReq *dropErabSetupReq);
 
 EXTERN NbDamCb nbDamCb;
 
@@ -1660,3 +1661,22 @@ PUBLIC S16 NbEnbDropRA(NbDropRA *dropRA) {
   RETVALUE(ROK);
 }
 
+ /* @details This function marks a ue for dropping Erab Setup Request
+ *
+ * Function: NbHandleDropErabSetupReq
+ *
+ * @param[in]  NbHandleDropErabSetupReq
+ * @return  S16
+ *          -# Success : ROK
+ */
+PUBLIC S16 NbHandleDropErabSetupReq(NbDropErabSetupReq *dropErabSetupReq) {
+   NB_LOG_ENTERFN(&nbCb);
+
+   if (NULLP == dropErabSetupReq) {
+     NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+     RETVALUE(RFAILED);
+   }
+   nbCb.dropErabSetupCfg[(dropErabSetupReq->ueId) - 1]
+       .isDropErabSetupReqEnable = dropErabSetupReq->isDropErabSetupReqEnable;
+   RETVALUE(ROK);
+ }

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -450,6 +450,10 @@ typedef struct _InitCtxtSetupFailedErabs {
   NbUeMsgCause cause;
 } InitCtxtSetupRspFailedErabs;
 
+typedef struct _dropErabSetupCfg {
+  Bool isDropErabSetupReqEnable;
+} NbDropErabSetupCfg;
+
 typedef struct _EnbCb
 {
    CmHashListEnt nbHashEnt;
@@ -521,6 +525,7 @@ typedef struct _nbCb
    InitCtxtSetupRspFailedErabs  initCtxtSetupFailedErabs[NB_MAX_UE_SUPPORTED];
    DropRA                       dropRA[NB_MAX_UE_SUPPORTED];
    NbRouterSolicitCb            *rsCb[NB_MAX_UE_SUPPORTED];
+   NbDropErabSetupCfg dropErabSetupCfg[NB_MAX_UE_SUPPORTED];
 #ifdef MULTI_ENB_SUPPORT
    Bool                      x2HoDone;
 #endif

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2375,6 +2375,10 @@ PUBLIC S16 nbPrcIncS1apMsg(NbUeCb *ueCb, S1apPdu *pdu, U8 msgType)
    else if(procedureCodeVal == 5 ) /* rab setup request */
    {
       NB_LOG_DEBUG(&nbCb,"nbPrcIncS1apMsg(): Handling RAB Setup Request message\n");
+      if (nbCb.dropErabSetupCfg[(ueCb->ueId) - 1].isDropErabSetupReqEnable) {
+        nbUiSendErabSetupDrpdIndToUser(ueCb->ueId);
+        RETVALUE(ROK);
+      }
       ret = nbHandleRabSetupMsg(ueCb,pdu);
    }
    else if(procedureCodeVal == 23) /* context release command message */

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -8,17 +8,17 @@
 
 /**********************************************************************
 
-    Name:  LTE S1SIM - ENODEB Application Module 
+    Name:  LTE S1SIM - ENODEB Application Module
 
     Type:  C include file
 
     Desc:  C source code for ENODEB Application
-               
+
     File:  nb_ui.c
 
-    Sid:   
+    Sid:
 
-     Prg:      
+     Prg:
 
 **********************************************************************/
 #include "nb.h"
@@ -155,7 +155,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_INIT_CTXT_SETUP_FAIL:
          {
@@ -165,7 +164,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_DROP_INIT_CTXT_SETUP:
          {
@@ -176,7 +174,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_DELAY_INIT_CTXT_SETUP_RSP:
          {
@@ -187,7 +184,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_INIT_CTXT_SETUP_RSP_FAILED_ERABS: {
         if (ROK != NbEnbHandleInitCtxtSetupRspFailedErabs(
@@ -206,7 +202,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_SEND_UE_CTXT_REL_FOR_ICS:
          {
@@ -217,7 +212,6 @@ PUBLIC S16 NbUiNbtMsgReq
                      "from TFW");
             }
             break;
-            
          }
       case NB_MULTI_ENB_CONFIG_REQ:
          {
@@ -257,51 +251,43 @@ PUBLIC S16 NbUiNbtMsgReq
     }
     break;
   }
+  case NB_DROP_ERAB_SETUP_REQ: {
+    if (ROK != NbHandleDropErabSetupReq(&req->t.dropErabSetupReq)) {
+      NB_LOG_ERROR(&nbCb,
+                   "Failed to process Drop Erab Setup Request from TFW \n");
+    }
+    break;
+  }
 
-      default:
-         NB_LOG_ERROR(&nbCb,"Invalid msgType");
-         break;
+  default:
+    NB_LOG_ERROR(&nbCb, "Invalid msgType");
+    break;
    }
    /* need to free received buffer */
    RETVALUE(ROK);
 } /* NbUiNbtMsgReq */
 
-PUBLIC S16 NbUiNbuHdlInitialUeMsg 
-(
- Pst *pst,
- NbuInitialUeMsg *req
-)
-{
-   S16 retVal = ROK;
+PUBLIC S16 NbUiNbuHdlInitialUeMsg(Pst *pst, NbuInitialUeMsg *req) {
+  S16 retVal = ROK;
 
-   retVal = NbHandleInitialUeMsg(req);
-   /* free the received message */
-   NB_FREE(req->nasPdu.val, req->nasPdu.len);
-   NB_FREE(req, sizeof(NbuInitialUeMsg));
-   RETVALUE(retVal);
+  retVal = NbHandleInitialUeMsg(req);
+  /* free the received message */
+  NB_FREE(req->nasPdu.val, req->nasPdu.len);
+  NB_FREE(req, sizeof(NbuInitialUeMsg));
+  RETVALUE(retVal);
 } /* NbUiNbuHdlInitialUeMsg */
 
-PUBLIC S16 NbUiNbuHdlUeIpInfoRsp 
-(
- Pst *pst,
- NbuUeIpInfoRsp *rsp
-)
-{
-   S16 retVal = ROK;
+PUBLIC S16 NbUiNbuHdlUeIpInfoRsp(Pst *pst, NbuUeIpInfoRsp *rsp) {
+  S16 retVal = ROK;
 
-   retVal = NbHandleUeIpInfoRsp(rsp);
-   RETVALUE(retVal);
+  retVal = NbHandleUeIpInfoRsp(rsp);
+  RETVALUE(retVal);
 } /* NbUiNbuHdlUeIpInfoRsp */
-PUBLIC S16 NbUiNbuHdlErabRelInd 
-(
- Pst *pst,
- NbuErabRelIndList *msg
-)
-{
-   S16 retVal = ROK;
+PUBLIC S16 NbUiNbuHdlErabRelInd(Pst *pst, NbuErabRelIndList *msg) {
+  S16 retVal = ROK;
 
-   retVal = NbEnbErabRelIndHdl(msg);
-   RETVALUE(retVal);
+  retVal = NbEnbErabRelIndHdl(msg);
+  RETVALUE(retVal);
 } /* NbUiNbuHdlErabRelInd */
 PUBLIC S16 NbUiNbuHdlUlNasMsg
 (
@@ -346,12 +332,12 @@ PUBLIC S16 NbUiNbuHdlUlNasMsg
    /* set the datrcvd flag for ue */
    nbDamSetDatFlag(ueId);
    s1apConCb = ueCb->s1ConCb;
-   if(s1apConCb == NULLP || ((s1apConCb != NULLP) && 
-            (s1apConCb->s1apConnState != NB_S1AP_CONNECTED)))
-   {
-      NB_FREE(msg->nasPdu.val, msg->nasPdu.len);
-      NB_FREE(msg, sizeof(NbuUlNasMsg));
-      RETVALUE(RFAILED);
+   if (s1apConCb == NULLP ||
+       ((s1apConCb != NULLP) &&
+        (s1apConCb->s1apConnState != NB_S1AP_CONNECTED))) {
+     NB_FREE(msg->nasPdu.val, msg->nasPdu.len);
+     NB_FREE(msg, sizeof(NbuUlNasMsg));
+     RETVALUE(RFAILED);
    }
 #ifdef MULTI_ENB_SUPPORT
    EnbCb *enbCb = NULLP;
@@ -395,7 +381,7 @@ PUBLIC S16 NbUiNbuHdlUlNasMsg
    NB_FREE(msg, sizeof(NbuUlNasMsg));
 
    RETVALUE(ROK);
-} /* NbUiNbuHdlUlNasMsg */  
+} /* NbUiNbuHdlUlNasMsg */
 
 PUBLIC S16 NbUiNbuHdlUeRadioCapMsg
 (
@@ -442,12 +428,12 @@ PUBLIC S16 NbUiNbuHdlUeRadioCapMsg
    /* set the datrcvd flag for ue */
    nbDamSetDatFlag(ueId);
    s1apConCb = ueCb->s1ConCb;
-   if(s1apConCb == NULLP || ((s1apConCb != NULLP) && 
-            (s1apConCb->s1apConnState != NB_S1AP_CONNECTED)))
-   {
-      NB_FREE(msg->rrcPdu.val,msg->rrcPdu.len);
-      NB_FREE(msg,sizeof(NbuUlRrcMsg));
-      RETVALUE(RFAILED);
+   if (s1apConCb == NULLP ||
+       ((s1apConCb != NULLP) &&
+        (s1apConCb->s1apConnState != NB_S1AP_CONNECTED))) {
+     NB_FREE(msg->rrcPdu.val, msg->rrcPdu.len);
+     NB_FREE(msg, sizeof(NbuUlRrcMsg));
+     RETVALUE(RFAILED);
    }
 
    if(nbS1apBldUeCapIndPdu(ueCb,&msg->rrcPdu, &s1UlInfoMsg.pdu) != ROK)
@@ -483,29 +469,23 @@ PUBLIC S16 NbUiNbuHdlUeRadioCapMsg
    RETVALUE(ROK);
 } /* NbUiNbuHdlUeRadioCapMsg */
 
-PUBLIC S16 nbUiBuildAndSendDlNasMsg
-(
- NbUeCb       *ueCb,
- SztNAS_PDU   *nasPdu
-) 
-{
-   U8 idx = 0;
-   NbuDlNasMsg *msg = NULLP;
+PUBLIC S16 nbUiBuildAndSendDlNasMsg(NbUeCb *ueCb, SztNAS_PDU *nasPdu) {
+  U8 idx = 0;
+  NbuDlNasMsg *msg = NULLP;
 
-   NB_ALLOC(&msg, sizeof(NbuDlNasMsg));
-   msg->ueId = ueCb->ueId;
-   msg->nasPdu.len = nasPdu->len;
+  NB_ALLOC(&msg, sizeof(NbuDlNasMsg));
+  msg->ueId = ueCb->ueId;
+  msg->nasPdu.len = nasPdu->len;
 
-   NB_ALLOC(&msg->nasPdu.val, msg->nasPdu.len * sizeof(U8));
-   for(idx = 0 ; idx < nasPdu->len; idx++)
-   {
-      msg->nasPdu.val[idx] = nasPdu->val[idx];
-   }
+  NB_ALLOC(&msg->nasPdu.val, msg->nasPdu.len * sizeof(U8));
+  for (idx = 0; idx < nasPdu->len; idx++) {
+    msg->nasPdu.val[idx] = nasPdu->val[idx];
+  }
 
-   /* set the datrcvd flag for ue */
-   nbDamSetDatFlag(ueCb->ueId);
-   cmPkNbuDlNasMsg(&nbCb.ueAppPst, msg);
-   RETVALUE(ROK);
+  /* set the datrcvd flag for ue */
+  nbDamSetDatFlag(ueCb->ueId);
+  cmPkNbuDlNasMsg(&nbCb.ueAppPst, msg);
+  RETVALUE(ROK);
 } /* nbUiBuildAndSendDlNasMsg */
 
 /* eNb is not sending NAS NON DEL IND to TFW */
@@ -568,7 +548,7 @@ PUBLIC S16 nbUiBuildAndSendPagingMsg
       msg->ueIden.sTMSI.mmec = pagMsgInfo->ueIden.sTMSI.mmec;
       msg->ueIden.sTMSI.mTMSI = pagMsgInfo->ueIden.sTMSI.mTMSI;
    }
-   msg->domIndType = pagMsgInfo->domIndType; 
+   msg->domIndType = pagMsgInfo->domIndType;
    cmPkNbuPagingMsg(&nbCb.ueAppPst,msg);
    RETVALUE(ROK);
 } /* nbUiBuildAndSendPagingMsg */
@@ -599,7 +579,7 @@ PUBLIC Void nbUiSendS1TimeOutInd(Void)
    if(msg == NULLP)
       RETVOID;
    smCfgCb.smState = NB_SM_STATE_AWAIT_S1_CON;
-   msg->msgType = NB_S1_SETUP_TIMEOUT_IND; 
+   msg->msgType = NB_S1_SETUP_TIMEOUT_IND;
    if(ROK != cmPkNbtMsgRsp(&pst, msg))
    {
       NB_LOG_ERROR(&nbCb,"Failed to send message to TFWApp");
@@ -633,7 +613,7 @@ PUBLIC Void nbUiSendS1SetupFailInd
    if( wait != 0)
    {
       rsp->t.s1SetupRsp.waitIe.val   = wait;
-      rsp->t.s1SetupRsp.waitIe.pres  =  TRUE; 
+      rsp->t.s1SetupRsp.waitIe.pres = TRUE;
    }
    smCfgCb.smState = NB_SM_STATE_AWAIT_S1_CON;
    if(ROK != cmPkNbtMsgRsp(&pst, rsp))
@@ -662,8 +642,8 @@ PUBLIC Void nbUiSendConfigFailIndToUser(CfgFailCause cause)
    pst.pool = smCfgCb.init.pool;
    pst.srcInst = 0;
 
-   rsp->t.configCfm.status = CFG_DONE_NOK; 
-   rsp->t.configCfm.cause  = cause; 
+   rsp->t.configCfm.status = CFG_DONE_NOK;
+   rsp->t.configCfm.cause = cause;
    NB_LOG_ERROR(&nbCb,"SENDING THE CONFIGURATION CFM NOK  TO USER FW-API");
 
    smCfgCb.smState = NB_SM_STATE_AWAIT_S1_CON;
@@ -701,42 +681,36 @@ PUBLIC Void nbUiSendSuccessResponseToUser(NbMsgTypes msgType)
    pst.region = smCfgCb.init.region;
    pst.pool = smCfgCb.init.pool;
    pst.srcInst = 0;
-   if(msgType == NB_CONFIG_CFM)
-   { 
-      rsp->t.configCfm.status = CFG_DONE_ROK;
-   }
-   else if(msgType == NB_S1_SETUP_RSP)
-   {
-      rsp->t.s1SetupRsp.res = S1_SETUP_SUCC;
+   if (msgType == NB_CONFIG_CFM) {
+     rsp->t.configCfm.status = CFG_DONE_ROK;
+   } else if (msgType == NB_S1_SETUP_RSP) {
+     rsp->t.s1SetupRsp.res = S1_SETUP_SUCC;
 
-      /* Served GUMMEI list */
-      rsp->t.s1SetupRsp.numPlmnIds = mmeCb->numPlmnIds;
-      for (idx = 0; idx < mmeCb->numPlmnIds; idx++)
-      {
-         cmMemcpy((U8 *)&(rsp->t.s1SetupRsp.plmnIds[idx]),
-                  (U8 *)&(mmeCb->plmnIds[idx]), sizeof(NbtPlmnId));
-      }
+     /* Served GUMMEI list */
+     rsp->t.s1SetupRsp.numPlmnIds = mmeCb->numPlmnIds;
+     for (idx = 0; idx < mmeCb->numPlmnIds; idx++) {
+       cmMemcpy((U8 *)&(rsp->t.s1SetupRsp.plmnIds[idx]),
+                (U8 *)&(mmeCb->plmnIds[idx]), sizeof(NbtPlmnId));
+     }
 
-      rsp->t.s1SetupRsp.numGrpIds = mmeCb->numGrpIds;
-      for (idx = 0; idx < mmeCb->numGrpIds; idx++)
-      {
-         rsp->t.s1SetupRsp.groupIds[idx] = mmeCb->groupIds[idx];
-      }
+     rsp->t.s1SetupRsp.numGrpIds = mmeCb->numGrpIds;
+     for (idx = 0; idx < mmeCb->numGrpIds; idx++) {
+       rsp->t.s1SetupRsp.groupIds[idx] = mmeCb->groupIds[idx];
+     }
 
-      rsp->t.s1SetupRsp.numCodes = mmeCb->numCodes;
-      for (idx = 0; idx < mmeCb->numCodes; idx++)
-      {
-         rsp->t.s1SetupRsp.codes[idx] = mmeCb->codes[idx];
-      }
+     rsp->t.s1SetupRsp.numCodes = mmeCb->numCodes;
+     for (idx = 0; idx < mmeCb->numCodes; idx++) {
+       rsp->t.s1SetupRsp.codes[idx] = mmeCb->codes[idx];
+     }
 
-      /* Relative MME Capacity */
-      rsp->t.s1SetupRsp.relCapacity = mmeCb->relCapacity;
-      /* MME Name */
-      rsp->t.s1SetupRsp.mmeName.len = mmeCb->mmeName.len;
-      cmMemcpy(rsp->t.s1SetupRsp.mmeName.val, mmeCb->mmeName.val,
-               mmeCb->mmeName.len);
-      /* MME Relay Support Indication */
-      rsp->t.s1SetupRsp.mmeRelaySuppInd = mmeCb->mmeRelaySuppInd;
+     /* Relative MME Capacity */
+     rsp->t.s1SetupRsp.relCapacity = mmeCb->relCapacity;
+     /* MME Name */
+     rsp->t.s1SetupRsp.mmeName.len = mmeCb->mmeName.len;
+     cmMemcpy(rsp->t.s1SetupRsp.mmeName.val, mmeCb->mmeName.val,
+              mmeCb->mmeName.len);
+     /* MME Relay Support Indication */
+     rsp->t.s1SetupRsp.mmeRelaySuppInd = mmeCb->mmeRelaySuppInd;
    }
 
    if(ROK != cmPkNbtMsgRsp(&pst, rsp))
@@ -873,7 +847,7 @@ PUBLIC S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId)
 
    RETVALUE(ROK);
 }
- 
+
 PUBLIC S16 nbUiSendErabRelCmdInfoToUser(NbErabRelCmd *erabRelInfo)
 {
    NbtResponse *rsp = NULLP;
@@ -1035,3 +1009,29 @@ PUBLIC S16 NbUiNbuHdlUeIpInfoRej(Pst *pst, NbuUeIpInfoRej *rej) {
   retVal = NbHandleUeIpInfoRej(rej);
   RETVALUE(retVal);
 } /* NbUiNbuHdlUeIpInfoRej */
+
+PUBLIC S16 nbUiSendErabSetupDrpdIndToUser(U32 ueId) {
+  NbtResponse *rsp = NULLP;
+  Pst pst;
+  NB_ALLOC(&rsp, sizeof(NbtResponse));
+
+  rsp->msgType = NB_ERAB_SETUP_DROPPD_IND;
+  SM_SET_ZERO(&pst, sizeof(Pst));
+
+  pst.selector = 0;
+  pst.srcEnt = ENTNB;
+  pst.dstEnt = ENTFW;
+  pst.srcProcId = 0;
+  pst.dstProcId = 0;
+  pst.region = smCfgCb.init.region;
+  pst.pool = smCfgCb.init.pool;
+  pst.srcInst = 0;
+
+  rsp->t.erabSetupDropInd.ueId = ueId;
+
+  if (ROK != cmPkNbtMsgRsp(&pst, rsp)) {
+    NB_LOG_ERROR(&nbCb, "Failed to send message to TFW App");
+    RETVOID(RFAILED);
+  }
+  RETVALUE(ROK);
+}

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -57,6 +57,8 @@ typedef enum _nbMsgTypes
    // SCTP SHUTDOWN or ABORT
    NB_NW_INITIATED_ASSOC_DOWN,
    NB_DROP_RA,
+   NB_DROP_ERAB_SETUP_REQ,
+   NB_ERAB_SETUP_DROPPD_IND,
    NB_UNKNOWN_MSG_TYPE
 }NbMsgTypes;
 
@@ -338,6 +340,11 @@ typedef struct _nbIntCtxtSetUpDrpdInd
 {
    U32 ueId;
 }NbIntCtxtSetUpDrpdInd;
+typedef struct _nbErabSetUpDrpdInd
+{
+   U32 ueId;
+} NbErabSetUpDrpdInd;
+
 typedef struct _nbNasNonDel
 {
    U32 ueId;
@@ -446,6 +453,12 @@ typedef struct _nbDropRA {
   Bool isDropRA;
 } NbDropRA;
 
+typedef struct _nbDropErabSetupReq
+{
+   U32 ueId;
+   Bool isDropErabSetupReqEnable;
+} NbDropErabSetupReq;
+
 typedef struct _nbtMsg
 {
    NbMsgTypes msgType;
@@ -480,6 +493,8 @@ typedef struct _nbtMsg
       NbEnbConfigTrnsf    enbConfigTrnsf;
       NbMmeConfigTrnsf    mmeConfigTrnsf;
       NbDropRA dropRA;
+      NbDropErabSetupReq dropErabSetupReq;
+      NbErabSetUpDrpdInd  erabSetupDropInd;
    }t;
 }NbtMsg;
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -110,6 +110,7 @@ handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data);
 PRIVATE Void handleDropRouterAdv(UeDropRA *data);
 PUBLIC FwCb gfwCb;
 
+PRIVATE Void handleDropErabSetupReq(UeDropErabSetupReq_t *data);
 /* Adding UEID, epsupdate type, active flag into linked list for
  * TAU request
  */
@@ -2412,6 +2413,12 @@ PUBLIC S16 tfwApi
          }
          break;
       }
+      case UE_DROP_ERAB_SETUP_REQ: {
+        FW_LOG_DEBUG(fwCb,
+                     "Process UE_DROP_ERAB_SETUP_REQ message from testcase");
+        handleDropErabSetupReq((UeDropErabSetupReq_t *)msg);
+        break;
+      }
 
      default:
       {
@@ -3427,6 +3434,28 @@ PRIVATE Void handleDropRouterAdv(UeDropRA *data) {
   msgReq->msgType = NB_DROP_RA;
   msgReq->t.dropRA.ueId = data->ue_Id;
   msgReq->t.dropRA.isDropRA = data->flag;
+
+  fwSendToNbApp(msgReq);
+  RETVOID;
+}
+
+PRIVATE Void handleDropErabSetupReq(UeDropErabSetupReq_t * data) {
+  FwCb *fwCb = NULLP;
+  NbtRequest *msgReq = NULLP;
+
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
+
+  if (SGetSBuf(fwCb->init.region, fwCb->init.pool, (Data **)&msgReq,
+               (Size)sizeof(NbtRequest)) == ROK) {
+    cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
+  } else {
+    FW_LOG_ERROR(fwCb, "Failed to allocate memory");
+    RETVOID;
+  }
+  msgReq->msgType = NB_DROP_ERAB_SETUP_REQ;
+  msgReq->t.dropErabSetupReq.ueId = data->ue_Id;
+  msgReq->t.dropErabSetupReq.isDropErabSetupReqEnable = data->flag;
 
   fwSendToNbApp(msgReq);
   RETVOID;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -126,7 +126,9 @@ typedef enum {
    UE_SET_INIT_CTXT_SETUP_RSP_FAILED_ERABS,
    UE_STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT,
    UE_ROUTER_ADV_IND,
-   UE_SET_DROP_ROUTER_ADV
+   UE_SET_DROP_ROUTER_ADV,
+   UE_DROP_ERAB_SETUP_REQ,
+   UE_ERAB_DROP_IND
 }tfwCmd;
 
 typedef enum
@@ -141,7 +143,6 @@ typedef enum
    UE_ATTACH_ACCEPT_IND_DONE,
    UE_ATTACH_COMPLETE_DONE
 }attachState;
-
 
 typedef enum ue_state
 {
@@ -1359,6 +1360,12 @@ typedef struct _num_Of_Enbs
    U8   numOfEnb;
 }num_Of_Enbs_t;
 
+typedef struct ueDropErabSetupReq
+{
+   U32 ue_Id;
+   Bool flag;
+} UeDropErabSetupReq_t;
+
 typedef struct _fwNbConfigReq
 {
    cell_Id cellId_pr;
@@ -1501,6 +1508,11 @@ typedef struct _fwNbIntCtxSetupDrpdInd
 {
    U32 ueId;
 }FwNbIntCtxSetupDrpdInd_t;
+
+typedef struct _fwNbErabSetupDrpdInd
+{
+   U32 ueId;
+} FwNbErabSetupDrpdInd_t;
 
 typedef struct UeEmmInformation
 {

--- a/TestCntlrApp/src/tfwApp/fw_nbmsg_handler.c
+++ b/TestCntlrApp/src/tfwApp/fw_nbmsg_handler.c
@@ -63,17 +63,17 @@
 EXTERN FwCb gfwCb;
 PUBLIC S16 sendNbAppConfigRespToTstCntlr(NbConfigCfm *nbtMsg);
 /*
-*        Fun:   sendNbAppConfigRespToTstCntlr
-*
-*        Desc:  Sends the Nb Config Response message to 
-*               Test controller stub Message Queue
-*
-*        Ret:   S16
-* 
-*        Notes: None
-* 
-*        File:  fw_nbmsg_handler.c
-*/
+ *        Fun:   sendNbAppConfigRespToTstCntlr
+ *
+ *        Desc:  Sends the Nb Config Response message to
+ *               Test controller stub Message Queue
+ *
+ *        Ret:   S16
+ *
+ *        Notes: None
+ *
+ *        File:  fw_nbmsg_handler.c
+ */
 
 PUBLIC S16 sendNbAppS1SetupRespToTstCntlr(NbS1SetupRsp *nbtMsg);
 PUBLIC S16 sendNbAppS1SetupTimeOutIndToTstCntlr(Void);
@@ -86,10 +86,10 @@ PUBLIC S16 sendNbAppNasNonDelIndToTstCntlr(NbNasNonDelRsp *rsp);
 PUBLIC S16 sendNbAppPathSwReqAckToTstCntlr(NbPathSwReqAck *rsp);
 
 /*
- *       Fun: sendNbAppConfigRespToTstCntlr 
+ *       Fun: sendNbAppConfigRespToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -120,16 +120,15 @@ PUBLIC S16 sendNbAppConfigRespToTstCntlr(NbConfigCfm *cfm)
    {
       FW_LOG_ERROR(fwCb, "Memory Freeing failed");
    }
-   
+
    FW_LOG_EXITFN(fwCb, ret);
 } /* sendNbAppConfigRespToTstCntlr */
 
-
 /*
- *       Fun: sendNbAppS1SetupRespToTstCntlr 
+ *       Fun: sendNbAppS1SetupRespToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -160,7 +159,7 @@ PUBLIC S16 sendNbAppS1SetupRespToTstCntlr(NbS1SetupRsp *rsp)
          msg->waitIe.val  = rsp->waitIe.val;
          msg->waitIe.pres = TRUE;
       }
-      msg->cause.pres = TRUE; 
+      msg->cause.pres = TRUE;
       msg->cause.type = rsp->cause.causeType;
       msg->cause.val  = rsp->cause.causeVal;
       fwCb->nbState   = NB_CONFIG_DONE;
@@ -207,10 +206,10 @@ PUBLIC S16 sendNbAppS1SetupRespToTstCntlr(NbS1SetupRsp *rsp)
 } /* sendNbS1SetupRespToTstCntlr */
 
 /*
- *       Fun: sendNbAppS1ResetAckToTstCntlr 
+ *       Fun: sendNbAppS1ResetAckToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -249,10 +248,10 @@ PUBLIC S16 sendNbAppS1ResetAckToTstCntlr(NbResetAckldg *rsp)
 
 /*
  *
- *       Fun: sendNbAppS1SetupTimeOutIndToTstCntlr 
+ *       Fun: sendNbAppS1SetupTimeOutIndToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -276,8 +275,8 @@ PUBLIC S16 sendNbAppS1SetupTimeOutIndToTstCntlr(Void)
 /*
  *       Fun: sendNbAppUeCtxRelIndToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -306,8 +305,8 @@ PUBLIC S16 sendNbAppUeCtxRelIndToTstCntlr(NbUeCtxRelInd *rsp)
 /*
  *       Fun: sendNbAppIntCtxSetupIndToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -336,10 +335,10 @@ PUBLIC S16 sendNbAppIntCtxSetupIndToTstCntlr(NbIntCtxtSetUpInd *rsp)
 
 /*
  *
- *       Fun: sendNbAppIntCtxSetupDrpdIndToTstCntlr 
+ *       Fun: sendNbAppIntCtxSetupDrpdIndToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -363,13 +362,13 @@ PUBLIC S16 sendNbAppIntCtxSetupDrpdIndToTstCntlr(NbIntCtxtSetUpDrpdInd *rsp)
          sizeof(FwNbIntCtxSetupDrpdInd_t));
    FW_FREE_MEM(fwCb, msg, sizeof(FwNbIntCtxSetupDrpdInd_t));
    FW_LOG_EXITFN(fwCb, ret);
-} 
+}
 
 /*
  *       Fun: sendNbAppErabRelCmdToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -402,13 +401,42 @@ PUBLIC S16 sendNbAppErabRelCmdToTstCntlr(NbErabRelCmd *rsp)
    FW_LOG_EXITFN(fwCb, ret);
 } /* sendNbAppErabRelCmdToTstCntlr */
 
+/*
+ *
+ *       Fun: sendNbAppErabSetupDrpdIndToTstCntlr
+ *
+ *       Desc: Send ErabSetupReq drop indication to test controller
+ *
+ *       Ret:  ROK - ok; RFAILED - failed
+ *
+ *       Notes: none
+ *
+ *       File:  fw_nbmsg_handler.c
+ */
+PUBLIC S16 sendNbAppErabSetupDrpdIndToTstCntlr(NbErabSetUpDrpdInd *rsp) {
+  S16 ret = ROK;
+  FwCb *fwCb = NULLP;
+  FwNbErabSetupDrpdInd_t *msg = NULLP;
+  FW_LOG_ENTERFN(fwCb);
+
+  FW_GET_CB(fwCb);
+  FW_ALLOC_MEM(fwCb, &msg, sizeof(FwNbErabSetupDrpdInd_t));
+
+  msg->ueId = rsp->ueId;
+
+  (*fwCb->testConrollerCallBack)(UE_ERAB_DROP_IND, msg,
+                                 sizeof(FwNbErabSetupDrpdInd_t));
+  FW_FREE_MEM(fwCb, msg, sizeof(FwNbIntCtxSetupDrpdInd_t));
+  FW_LOG_EXITFN(fwCb, ret);
+}
+
 /*eNbApp wouldn't send NAS NON DEL IND to TFW */
 #if 0
 /*
  *       Fun: sendNbAppNasNonDelIndToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -438,8 +466,8 @@ PUBLIC S16 sendNbAppNasNonDelIndToTstCntlr(NbNasNonDelRsp *rsp)
 /*
  *       Fun: sendNbAppPathSwReqAckToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -465,11 +493,11 @@ PUBLIC S16 sendNbAppPathSwReqAckToTstCntlr(NbPathSwReqAck *rsp)
    FW_LOG_EXITFN(fwCb, ret);
 } /* sendNbAppPathSwReqAckToTstCntlr */
 
- /*
+/*
  *       Fun: sendNbAppMmeConfigTrfToTstCntlr
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -518,8 +546,8 @@ PUBLIC Void handleNwInitAssocDown() {
  *
  *       Fun: handleNbAppMsg
  *
- *       Desc: 
- * 
+ *       Desc:
+ *
  *       Ret:  ROK - ok; RFAILED - failed
  *
  *       Notes: none
@@ -589,7 +617,7 @@ PUBLIC S16 handleNbAppMsg
       case NB_PATH_SW_REQ_ACK:
          FW_LOG_DEBUG(fwCb, "Recieved Path Sw Req from EnodeB");
          sendNbAppPathSwReqAckToTstCntlr(&nbRspMsg->t.pathSwReqAck);
-         break;         
+         break;
       case NB_MME_CONFIG_TRANSFER:
          FW_LOG_DEBUG(fwCb, "Recieved NB_MME_CONFIG_TRF from EnodeB");
          sendNbAppMmeConfigTrfToTstCntlr(&nbRspMsg->t.mmeConfigTrnsf);
@@ -598,6 +626,10 @@ PUBLIC S16 handleNbAppMsg
          FW_LOG_DEBUG(fwCb, "Recieved NB_NW_INITIATED_ASSOC_DOWN from EnodeB");
          handleNwInitAssocDown();
          break;
+      case NB_ERAB_SETUP_DROPPD_IND:
+        FW_LOG_DEBUG(fwCb, "Recieved NB_ERAB_SETUP_DROPPD_IND from EnodeB");
+        sendNbAppErabSetupDrpdIndToTstCntlr(&nbRspMsg->t.intCtxtSetUpDrpdInd);
+        break;
       default:
          FW_LOG_ERROR(fwCb, "Recieved Invalid event from EnodeB");
          break;

--- a/TestCntlrApp/src/ueApp/ueAppdbm.x
+++ b/TestCntlrApp/src/ueApp/ueAppdbm.x
@@ -8,18 +8,18 @@
 
 /**********************************************************************
 
-    Name:  LTE UESIM - Sample Application Module 
- 
+    Name:  LTE UESIM - Sample Application Module
+
     Type:  C include file
- 
+
     Desc:  C source code for UE Sample Application
- 
-    File:  ueAppdbm.x 
- 
-    Sid:      
- 
-    Prg:    
- 
+
+    File:  ueAppdbm.x
+
+    Sid:
+
+    Prg:
+
 **********************************************************************/
 #include "cm_llist.h"      /* cm link list */
 #include "cm_llist.x"      /* cm link list */
@@ -157,7 +157,7 @@ typedef enum ueEcmState
    UE_ECM_IDLE = 0,          /* UE ECM IDLE */
    UE_ECM_CONNECTED          /* UE ECM_CONNECTED */
 }UeEcmState;
-	
+
 typedef enum ueTransState
 {
    UE_DETACHED = 0,              /* UE Detached */
@@ -174,9 +174,9 @@ typedef struct ueAppNwId
 
 typedef struct ueAppGUMMEI
 {
-   UeAppNwId  nwId;           /* Serving Network with PLMN ID */ 
+   UeAppNwId  nwId;           /* Serving Network with PLMN ID */
    U8         mmeCode;        /* MME Code */
-   U16        mmeGrpId;       /* MME Group ID */ 
+   U16        mmeGrpId;       /* MME Group ID */
 }UeAppGUMMEI;
 
 typedef struct ueAppInfo
@@ -268,7 +268,7 @@ typedef struct _ueCb
    UeEsmCb     *esmTList[CM_ESM_MAX_BEARER_ID];
    /* BID List of ESM Cbs. BID range is 5-15 */
    UeEsmCb     *esmBList[CM_ESM_MAX_BEARER_ID];
-   U32         transIdCntr;   /* Transaction counter for sending the 
+   U32         transIdCntr;   /* Transaction counter for sending the
                                  ESM Procedural transactions. */
    U16         cellId; /* cellId */
    U32         ueId;   /* ueId */
@@ -302,10 +302,10 @@ typedef struct _ueCb
 
 typedef struct _ueAppCb
 {
-   TskInit          init;       
+   TskInit          init;
    Pst              nbPst;
    Pst              fwPst;
-   U32              trfGenIfAddr; /* IP address of eth port connected to 
+   U32              trfGenIfAddr; /* IP address of eth port connected to
                                      traffic generator*/
    U8               NASProcGuardtimer; /* timer value */
    U32              numOfUeCfgd;


### PR DESCRIPTION
## Title
Added code to drop E-Rab Setup Request message
## Summary
In order to validate 3485 timer for default bearer, Added code to drop the first E-Rab Setup request message and respond to re-transmitted E-Rab Setup Request message. Test framework indicates to eNB application to drop the first E-Rab Setup Request message and provide an indication to test framework that eNB application has dropped the message. 
When test case intends to respond, test framework shall again indicate to disable the dropping of E-Rab Setup request message.

## Test plan
Executed s1ap sanity test suite
 