### PR TITLE
[new scenario] Out of order erab setup rsp

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1642,20 +1642,20 @@ PUBLIC S16 nbPrcMMEConfigTrf
  *
  * Function: NbEnbDelayErabSetupRsp
  *
- *
  * @param[in]  NbDelayErabSetupRsp
  * @return  S16
  *          -# Success : ROK
+ *          -# Failure : RFAILED
  */
 PUBLIC S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp *delayErabRsp) {
   NB_LOG_ENTERFN(&nbCb);
 
   if (NULLP == delayErabRsp) {
-    NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+    NB_LOG_ERROR(&nbCb, "Received empty(NULL) NbDelayErabSetupRsp request");
     RETVALUE(RFAILED);
   }
 
-  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].delayErabSetupRsp =
+  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].isDelayErabSetupRsp =
       delayErabRsp->isDelayErabSetupRsp;
   nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal =
       delayErabRsp->tmrVal;

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1638,7 +1638,7 @@ PUBLIC S16 nbPrcMMEConfigTrf
 #endif
 
 /*
- * @details This function marks a ue for delay erab setup rsp
+ * @details This function sets a flag in nbCb to delay erab setup rsp
  *
  * Function: NbEnbDelayErabSetupRsp
  *
@@ -1658,7 +1658,6 @@ PUBLIC S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp *delayErabRsp)
 
   nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].delayErabSetupRsp  = delayErabRsp->isDelayErabSetupRsp;
   nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal  = delayErabRsp->tmrVal;
-  printf("In NbEnbDelayErabSetupRsp tmrVal %d\n", nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal);
 
   RETVALUE(ROK);
 }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1647,17 +1647,18 @@ PUBLIC S16 nbPrcMMEConfigTrf
  * @return  S16
  *          -# Success : ROK
  */
-PUBLIC S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp *delayErabRsp)
-{
+PUBLIC S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp *delayErabRsp) {
   NB_LOG_ENTERFN(&nbCb);
 
-  if(NULLP == delayErabRsp) {
+  if (NULLP == delayErabRsp) {
     NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
     RETVALUE(RFAILED);
   }
 
-  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].delayErabSetupRsp  = delayErabRsp->isDelayErabSetupRsp;
-  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal  = delayErabRsp->tmrVal;
+  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].delayErabSetupRsp =
+      delayErabRsp->isDelayErabSetupRsp;
+  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal =
+      delayErabRsp->tmrVal;
 
   RETVALUE(ROK);
 }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1636,3 +1636,30 @@ PUBLIC S16 nbPrcMMEConfigTrf
    RETVALUE(ROK);
 } /* nbPrcS1SetupRsp */
 #endif
+
+/*
+ * @details This function marks a ue for delay erab setup rsp
+ *
+ * Function: NbEnbDelayErabSetupRsp
+ *
+ *
+ * @param[in]  NbDelayErabSetupRsp
+ * @return  S16
+ *          -# Success : ROK
+ */
+PUBLIC S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp *delayErabRsp)
+{
+  NB_LOG_ENTERFN(&nbCb);
+
+  if(NULLP == delayErabRsp) {
+    NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+    RETVALUE(RFAILED);
+  }
+
+  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].delayErabSetupRsp  = delayErabRsp->isDelayErabSetupRsp;
+  nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal  = delayErabRsp->tmrVal;
+  printf("In NbEnbDelayErabSetupRsp tmrVal %d\n", nbCb.delayErabSetupRsp[(delayErabRsp->ueId) - 1].tmrVal);
+
+  RETVALUE(ROK);
+}
+

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -267,7 +267,7 @@ typedef struct _nbErabSetupRspCb {
   U32 ueId;
   NbErabLst *erabInfo;
   NbFailedErabLst *failedErabInfo;
-  CmTimer   timer;
+  CmTimer timer;
 } NbErabSetupRspCb;
 
 typedef struct _nbDelayUeCtxtRelCmpCb
@@ -456,7 +456,7 @@ typedef struct _InitCtxtSetupFailedErabs {
 
 typedef struct _delayErabSetupRsp {
   Bool delayErabSetupRsp;
-  U32  tmrVal;
+  U32 tmrVal;
 } DelayErabSetupRsp;
 
 typedef struct _EnbCb

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -455,7 +455,7 @@ typedef struct _InitCtxtSetupFailedErabs {
 } InitCtxtSetupRspFailedErabs;
 
 typedef struct _delayErabSetupRsp {
-  Bool delayErabSetupRsp;
+  Bool isDelayErabSetupRsp;
   U32 tmrVal;
 } DelayErabSetupRsp;
 

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -263,6 +263,13 @@ typedef struct _nbDelayICSRspCb
  CmTimer   timer;
 }NbDelayICSRspCb;
 
+typedef struct _nbErabSetupRspCb {
+  U32 ueId;
+  NbErabLst *erabInfo;
+  NbFailedErabLst *failedErabInfo;
+  CmTimer   timer;
+}NbErabSetupRspCb;
+
 typedef struct _nbDelayUeCtxtRelCmpCb
 {
  U32 ueId;
@@ -283,7 +290,8 @@ typedef enum nbTmr
    NB_TMR_UE_CTX_REL_REQ,
    NB_TMR_LCL_UE_CTXT_REL_REQ,
    NB_TMR_DELAY_ICS_RSP,
-   NB_TMR_DELAY_UE_CTX_REL_COMP
+   NB_TMR_DELAY_UE_CTX_REL_COMP,
+   NB_TMR_DELAY_ERAB_SETUP_RSP
 } enNbTimer;
 
 typedef struct _nbS1ConnCb
@@ -446,6 +454,12 @@ typedef struct _InitCtxtSetupFailedErabs {
   NbUeMsgCause cause;
 } InitCtxtSetupRspFailedErabs;
 
+typedef struct _delayErabSetupRsp
+{
+   Bool delayErabSetupRsp;
+   U32   tmrVal;
+}DelayErabSetupRsp;
+
 typedef struct _EnbCb
 {
    CmHashListEnt nbHashEnt;
@@ -497,6 +511,7 @@ typedef struct _nbCb
    DropICSSndCtxtRelCfg      dropICSSndCtxtRel[NB_MAX_UE_SUPPORTED];
    DelayUeCtxtRelCmpCfg      delayUeCtxtRelCmp[NB_MAX_UE_SUPPORTED];
    InitCtxtSetupRspFailedErabs  initCtxtSetupFailedErabs[NB_MAX_UE_SUPPORTED];
+   DelayErabSetupRsp         delayErabSetupRsp[NB_MAX_UE_SUPPORTED];
 #ifdef MULTI_ENB_SUPPORT
    Bool                      x2HoDone;
 #endif

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -268,7 +268,7 @@ typedef struct _nbErabSetupRspCb {
   NbErabLst *erabInfo;
   NbFailedErabLst *failedErabInfo;
   CmTimer   timer;
-}NbErabSetupRspCb;
+} NbErabSetupRspCb;
 
 typedef struct _nbDelayUeCtxtRelCmpCb
 {
@@ -454,11 +454,10 @@ typedef struct _InitCtxtSetupFailedErabs {
   NbUeMsgCause cause;
 } InitCtxtSetupRspFailedErabs;
 
-typedef struct _delayErabSetupRsp
-{
-   Bool delayErabSetupRsp;
-   U32   tmrVal;
-}DelayErabSetupRsp;
+typedef struct _delayErabSetupRsp {
+  Bool delayErabSetupRsp;
+  U32  tmrVal;
+} DelayErabSetupRsp;
 
 typedef struct _EnbCb
 {

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2301,24 +2301,14 @@ PRIVATE S16 nbHandleRabSetupMsg(NbUeCb *ueCb, S1apPdu *pdu) {
       }
     }
     // Start a timer to delay sending of erab setup rsp
-    if (nbCb.delayErabSetupRsp[(ueCb->ueId) - 1].delayErabSetupRsp) {
+    if (nbCb.delayErabSetupRsp[(ueCb->ueId) - 1].isDelayErabSetupRsp) {
       retVal = nbStartDelayTimerForErabRsp(
           ueCb->ueId, erabInfo, failedErabInfo,
           nbCb.delayErabSetupRsp[(ueCb->ueId) - 1].tmrVal);
-      nbCb.delayErabSetupRsp[(ueCb->ueId) - 1].delayErabSetupRsp = FALSE;
+      nbCb.delayErabSetupRsp[(ueCb->ueId) - 1].isDelayErabSetupRsp = FALSE;
       RETVALUE(retVal);
     }
     retVal = nbRabSetupSndS1apRsp(ueCb, erabInfo, failedErabInfo);
-    if (retVal != ROK) {
-      NB_FREE(erabInfo->erabs, (erabInfo->noOfComp * sizeof(NbErabCb)));
-      NB_FREE(erabInfo, sizeof(NbErabLst));
-      if (failedErabInfo) {
-        NB_FREE(failedErabInfo->failedErabs,
-                (failedErabInfo->noOfComp * sizeof(NbFailedErab)));
-        NB_FREE(failedErabInfo, sizeof(NbFailedErabLst));
-      }
-      RETVALUE(RFAILED);
-    }
     NB_FREE(erabInfo->erabs, (erabInfo->noOfComp * sizeof(NbErabCb)));
     NB_FREE(erabInfo, sizeof(NbErabLst));
     if (failedErabInfo) {

--- a/TestCntlrApp/src/enbApp/nb_tmr.c
+++ b/TestCntlrApp/src/enbApp/nb_tmr.c
@@ -132,7 +132,8 @@ U32                          delay
    NbUeCb                    *ueCb   = NULLP;
    NbDelayICSRspCb *icsRspCb = NULLP;
    NbDelayUeCtxtRelCmpCb *ueCtxRelCmp = NULLP;
- 
+   NbErabSetupRspCb *erabSetupRspCb = NULLP;
+
    wait = 0;
    wait = NB_CALC_WAIT_TIME(delay);
    switch (tmrEvnt)
@@ -178,6 +179,13 @@ U32                          delay
       {
          ueCtxRelCmp = (NbDelayUeCtxtRelCmpCb *)cb;
          tmr = &ueCtxRelCmp->timer;
+         maxTmrs = 1;
+         break;
+      }
+      case NB_TMR_DELAY_ERAB_SETUP_RSP:
+      {
+         erabSetupRspCb = (NbErabSetupRspCb *)cb;
+         tmr = &erabSetupRspCb->timer;
          maxTmrs = 1;
          break;
       }
@@ -338,6 +346,7 @@ S16                          event
    NbUeCb                    *ueCb;
    NbDelayICSRspCb           *icsRspCb;
    NbDelayUeCtxtRelCmpCb     *ueCtxtRelCb;
+   NbErabSetupRspCb *erabSetupRspCb;
   /*U32 size;*/
    switch(event)
    {
@@ -386,6 +395,14 @@ S16                          event
          /*HandleDelayTimerForICSExpiry(ueCtxtRelCb);*/
          break;
       }
+      case NB_TMR_DELAY_ERAB_SETUP_RSP:
+      {
+         erabSetupRspCb = (NbErabSetupRspCb *)cb;
+         NB_LOG_DEBUG(&nbCb,"ERAB_SETUP_RSP Timer Expired for UE:[%d]",erabSetupRspCb->ueId);
+         nbHandleDelayTimerForErabSetupRspExpiry(erabSetupRspCb);
+         break;
+      }
+ 
       default:
          {
             /* Invalid Timer */

--- a/TestCntlrApp/src/enbApp/nb_tmr.c
+++ b/TestCntlrApp/src/enbApp/nb_tmr.c
@@ -182,12 +182,11 @@ U32                          delay
          maxTmrs = 1;
          break;
       }
-      case NB_TMR_DELAY_ERAB_SETUP_RSP:
-      {
-         erabSetupRspCb = (NbErabSetupRspCb *)cb;
-         tmr = &erabSetupRspCb->timer;
-         maxTmrs = 1;
-         break;
+      case NB_TMR_DELAY_ERAB_SETUP_RSP: {
+        erabSetupRspCb = (NbErabSetupRspCb *)cb;
+        tmr = &erabSetupRspCb->timer;
+        maxTmrs = 1;
+        break;
       }
       default:
       {
@@ -395,14 +394,13 @@ S16                          event
          /*HandleDelayTimerForICSExpiry(ueCtxtRelCb);*/
          break;
       }
-      case NB_TMR_DELAY_ERAB_SETUP_RSP:
-      {
-         erabSetupRspCb = (NbErabSetupRspCb *)cb;
-         NB_LOG_DEBUG(&nbCb,"ERAB_SETUP_RSP Timer Expired for UE:[%d]",erabSetupRspCb->ueId);
-         nbHandleDelayTimerForErabSetupRspExpiry(erabSetupRspCb);
-         break;
+      case NB_TMR_DELAY_ERAB_SETUP_RSP: {
+        erabSetupRspCb = (NbErabSetupRspCb *)cb;
+        NB_LOG_DEBUG(&nbCb,"ERAB_SETUP_RSP Timer Expired for UE:[%d]",erabSetupRspCb->ueId);
+        nbHandleDelayTimerForErabSetupRspExpiry(erabSetupRspCb);
+        break;
       }
- 
+
       default:
          {
             /* Invalid Timer */

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -52,6 +52,7 @@ EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId);
 EXTERN S16 NbEnbDelayUeCtxtRelCmp(NbDelayUeCtxtRelCmp*);
 EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 EXTERN S16 NbUiNbuHdlUeIpInfoRej(Pst *, NbuUeIpInfoRej *);
+EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayICSRsp*);
 
 int atoi(const char *nptr);
 
@@ -249,6 +250,14 @@ PUBLIC S16 NbUiNbtMsgReq
       }
 
 #endif
+      case NB_DELAY_ERAB_SETUP_RSP: {
+        if(ROK != NbEnbDelayErabSetupRsp(&req->t.delayErabSetupRsp)) {
+          NB_LOG_ERROR(&nbCb, "Failed to process Delay Erab Setup Rsp  "\
+                     "from TFW");
+        }
+        break;
+      }
+
       default:
          NB_LOG_ERROR(&nbCb,"Invalid msgType");
          break;

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -52,7 +52,7 @@ EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId);
 EXTERN S16 NbEnbDelayUeCtxtRelCmp(NbDelayUeCtxtRelCmp*);
 EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 EXTERN S16 NbUiNbuHdlUeIpInfoRej(Pst *, NbuUeIpInfoRej *);
-EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayICSRsp *);
+EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp  *);
 
 int atoi(const char *nptr);
 
@@ -252,7 +252,7 @@ PUBLIC S16 NbUiNbtMsgReq
 #endif
       case NB_DELAY_ERAB_SETUP_RSP: {
         if(ROK != NbEnbDelayErabSetupRsp(&req->t.delayErabSetupRsp)) {
-          NB_LOG_ERROR(&nbCb, "Failed to process Delay Erab Setup Rsp  "\
+          NB_LOG_ERROR(&nbCb, "Failed to process Delay Erab Setup Rsp "\
                      "from TFW");
         }
         break;

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -52,7 +52,7 @@ EXTERN S16 nbUiSendIntCtxtSetupDrpdIndToUser(U32 ueId);
 EXTERN S16 NbEnbDelayUeCtxtRelCmp(NbDelayUeCtxtRelCmp*);
 EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 EXTERN S16 NbUiNbuHdlUeIpInfoRej(Pst *, NbuUeIpInfoRej *);
-EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayICSRsp*);
+EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayICSRsp *);
 
 int atoi(const char *nptr);
 

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -56,6 +56,7 @@ typedef enum _nbMsgTypes
    NB_MME_CONFIG_TRANSFER,
    // SCTP SHUTDOWN or ABORT
    NB_NW_INITIATED_ASSOC_DOWN,
+   NB_DELAY_ERAB_SETUP_RSP,
    NB_UNKNOWN_MSG_TYPE
 }NbMsgTypes;
 
@@ -440,6 +441,12 @@ typedef struct _nbMmeConfigTrnsf
   }u;
 }NbMmeConfigTrnsf;
 
+typedef struct _nbDelayErabSetupRsp {
+  U32 ueId;
+  Bool isDelayErabSetupRsp;
+  U32 tmrVal;
+} NbDelayErabSetupRsp;
+
 typedef struct _nbtMsg
 {
    NbMsgTypes msgType;
@@ -473,6 +480,7 @@ typedef struct _nbtMsg
       NbTunDelReq         tunDelReq;
       NbEnbConfigTrnsf    enbConfigTrnsf;
       NbMmeConfigTrnsf    mmeConfigTrnsf;
+      NbDelayErabSetupRsp delayErabSetupRsp;
    }t;
 }NbtMsg;
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -2402,19 +2402,16 @@ PUBLIC S16 tfwApi
             (ueActvDfltEpsBearerCtxtRej_t *)msg);
         break;
       }
-      case UE_SET_DELAY_ERAB_SETUP_RSP:
-      {
-         FW_LOG_DEBUG(fwCb, "Process Delay ERAB_SETUP_RSP Request ");
-         if (fwCb->nbState == ENB_IS_UP)
-         {
-            handleDelayErabSetupRsp((UeDelayErabSetupRsp*)msg);
-         }
-         else
-         {
-            FW_LOG_ERROR(fwCb, "Failed To Process ERAB Setup Rsp delay Request:ENBAPP IS NOT UP");
-            ret = RFAILED;
-         }
-         break;
+      case UE_SET_DELAY_ERAB_SETUP_RSP: {
+        FW_LOG_DEBUG(fwCb, "Process Delay ERAB_SETUP_RSP Request ");
+        if (fwCb->nbState == ENB_IS_UP) {
+          handleDelayErabSetupRsp((UeDelayErabSetupRsp*)msg);
+        }
+        else {
+          FW_LOG_ERROR(fwCb, "Failed to process ERAB Setup Rsp delay request:ENBAPP IS NOT UP");
+          ret = RFAILED;
+        }
+        break;
       }
 
      default:
@@ -3404,7 +3401,8 @@ handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data) {
  *
  *   Fun:   handleDelayErabSetupRsp
  *
- *   Desc:  This function is used to handle Delay Erab Setup Response
+ *   Desc:  This function is used to process Delay Erab Setup Response
+ *          message received from the test script
  *
  *   Ret:   None
  *
@@ -3413,31 +3411,27 @@ handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data) {
  *   File:  fw_api_int.c
  *
  */
-PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp* data)
-{
-   FwCb *fwCb = NULLP;
-   NbtRequest *msgReq = NULLP;
+PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp* data) {
+  FwCb *fwCb = NULLP;
+  NbtRequest *msgReq = NULLP;
 
-   FW_GET_CB(fwCb);
-   FW_LOG_ENTERFN(fwCb);
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
 
-   if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
-       (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK)
-   {
-      cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
-   }
-   else
-   {
-      FW_LOG_ERROR(fwCb, "Failed to allocate memory");
-      RETVOID;
-   }
+  if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
+      (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) {
+     cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
+  } else {
+     FW_LOG_ERROR(fwCb, "Failed to allocate memory");
+     RETVOID;
+  }
 
-   msgReq->msgType = NB_DELAY_ERAB_SETUP_RSP;
-   msgReq->t.delayErabSetupRsp.ueId = data->ue_Id;
-   msgReq->t.delayErabSetupRsp.isDelayErabSetupRsp = data->flag;
-   msgReq->t.delayErabSetupRsp.tmrVal = data->tmrVal;
+  msgReq->msgType = NB_DELAY_ERAB_SETUP_RSP;
+  msgReq->t.delayErabSetupRsp.ueId = data->ue_Id;
+  msgReq->t.delayErabSetupRsp.isDelayErabSetupRsp = data->flag;
+  msgReq->t.delayErabSetupRsp.tmrVal = data->tmrVal;
 
-   fwSendToNbApp(msgReq);
-   RETVOID;
+  fwSendToNbApp(msgReq);
+  RETVOID;
 }
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -2406,8 +2406,7 @@ PUBLIC S16 tfwApi
         FW_LOG_DEBUG(fwCb, "Process Delay ERAB_SETUP_RSP Request ");
         if (fwCb->nbState == ENB_IS_UP) {
           handleDelayErabSetupRsp((UeDelayErabSetupRsp*)msg);
-        }
-        else {
+        } else {
           FW_LOG_ERROR(fwCb, "Failed to process ERAB Setup Rsp delay request:ENBAPP IS NOT UP");
           ret = RFAILED;
         }

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -107,7 +107,7 @@ PRIVATE Void
 handleUeInitCtxtSetupRspFailedErabs(UeInitCtxtSetupFailedErabs *data);
 PUBLIC S16
 handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data);
-PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp* data);
+PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp *data);
 PUBLIC FwCb gfwCb;
 
 /* Adding UEID, epsupdate type, active flag into linked list for
@@ -3411,19 +3411,19 @@ handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data) {
  *   File:  fw_api_int.c
  *
  */
-PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp* data) {
+PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp *data) {
   FwCb *fwCb = NULLP;
   NbtRequest *msgReq = NULLP;
 
   FW_GET_CB(fwCb);
   FW_LOG_ENTERFN(fwCb);
 
-  if(SGetSBuf(fwCb->init.region, fwCb->init.pool,
-      (Data **)&msgReq, (Size)sizeof(NbtRequest)) == ROK) {
-     cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
+  if (SGetSBuf(fwCb->init.region, fwCb->init.pool, (Data **)&msgReq,
+               (Size)sizeof(NbtRequest)) == ROK) {
+    cmMemset((U8 *)(msgReq), 0, sizeof(NbtRequest));
   } else {
-     FW_LOG_ERROR(fwCb, "Failed to allocate memory");
-     RETVOID;
+    FW_LOG_ERROR(fwCb, "Failed to allocate memory");
+    RETVOID;
   }
 
   msgReq->msgType = NB_DELAY_ERAB_SETUP_RSP;
@@ -3434,4 +3434,3 @@ PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp* data) {
   fwSendToNbApp(msgReq);
   RETVOID;
 }
-

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -124,6 +124,7 @@ typedef enum {
    UE_AUTH_FAILURE,
    UE_SET_INIT_CTXT_SETUP_RSP_FAILED_ERABS,
    UE_STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT,
+   UE_SET_DELAY_ERAB_SETUP_RSP,
    UE_ROUTER_ADV_IND
 }tfwCmd;
 
@@ -1585,6 +1586,12 @@ typedef struct ueRouterAdv {
   U8 bearerId;
   U8 ipv6Addr[FW_ESM_MAX_IPV6_LEN];
 } ueRouterAdv_t;
+
+typedef struct ueDelayErabSetupRsp {
+  U32 ue_Id;
+  U32 tmrVal;
+  Bool flag;
+} UeDelayErabSetupRsp;
 
 typedef FwErabRelCmd_t FwErabRelRsp_t;
 


### PR DESCRIPTION
## Title
[new scenario] Out of order erab setup rsp

## Summary
This PR supports sending of erab setup rsp out-of-order i.e after activate default/dedicated eps bearer accept NAS message is sent

## Test plan
- Verified sanity
- Verified new TCs in magma PR #3817
