### PR TITLE
[new scenario] Simulate sending of service req with zero mac value

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -557,11 +557,11 @@ typedef struct _ueUetMtmsi
    U32 mTmsi;
 }UeUetMtmsi;
 
-typedef struct _ueUetServiceReq
-{
-   U32 ueId;
-   UeUetMtmsi ueMtmsi;
-   U8 rrcCause;
+typedef struct _ueUetServiceReq {
+  U32 ueId;
+  UeUetMtmsi ueMtmsi;
+  U8 rrcCause;
+  Bool noMac;
 }UeUetServiceReq;
 
 typedef struct _ueUetServiceRej

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -245,6 +245,7 @@ PUBLIC Void handlServiceReq(ueserviceReq_t* data)
    ueServiceReq->ueMtmsi.pres = data->ueMtmsi.pres;
    ueServiceReq->ueMtmsi.mTmsi = data->ueMtmsi.mTmsi;
    ueServiceReq->rrcCause = data->rrcCause;
+   ueServiceReq->noMac = data->noMac;
 
    fwSendToUeApp(uetMsg);
    RETVOID;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -913,11 +913,11 @@ typedef struct ueMtmsi
    U32 mTmsi;
 }ueMtmsi_t;
 
-typedef struct ueServiceReq
-{
-   U32 ue_Id;
-   ueMtmsi_t ueMtmsi;
-   U8 rrcCause;
+typedef struct ueServiceReq {
+  U32 ue_Id;
+  ueMtmsi_t ueMtmsi;
+  U8 rrcCause;
+  Bool noMac;
 }ueserviceReq_t;
 
 typedef struct _relCause

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -193,7 +193,7 @@ PRIVATE S16 ueBldServiceRejectIndToTfw(UetMessage*, UeCb*, U8);
 PRIVATE S16 ueBldDetachAcceptIndToTfw(UetMessage*, UeCb*, U8);
 PRIVATE S16 ueProcUeAttachFail(UetMessage*, Pst*);
 PRIVATE S16 ueAppUtlBldServiceReq(UeCb *ueCb, CmNasEvnt **ueEvt);
-PRIVATE S16 ueSendServiceRequest(UeCb *ueCb, U32 mTmsi, U8 rrcCause);
+PRIVATE S16 ueSendServiceRequest(UeCb *ueCb, U32 mTmsi, U8 rrcCause, Bool noMac);
 PRIVATE S16 ueProcUeServiceRequest(UetMessage *p_ueMsg, Pst *pst);
 PRIVATE S16 ueAppEmmHndlInAttachReject(CmNasEvnt *evnt, UeCb *ueCb);
 PRIVATE S16 ueBldTauRejectIndToTfw(UetMessage *tfwMsg, UeCb *ueCb, U8 cause);
@@ -4530,7 +4530,8 @@ PRIVATE S16 ueSendServiceRequest
 (
  UeCb *ueCb,
  U32 mTmsi,
- U8 rrcCause
+ U8 rrcCause,
+ Bool noMac
 )
 {
    S16 ret = ROK;
@@ -4548,6 +4549,9 @@ PRIVATE S16 ueSendServiceRequest
    UE_LOG_DEBUG(ueAppCb, "Sending UE Service Request message");
 
    ueCb->ecmCb.state = UE_ECM_CONNECTED;
+   if (noMac) {
+     ueCb->secCtxt.noMac = TRUE;
+   }
    ret = ueAppUtlBldServiceReq(ueCb, &serviceReqEvnt);
    if(ROK != ret)
    {
@@ -5099,6 +5103,7 @@ PRIVATE S16 ueProcUeServiceRequest
    UE_LOG_DEBUG(ueAppCb, "Recieved Ue Service Request");
    ueId = p_ueMsg->msg.ueUetServiceReq.ueId;
    rrcCause = p_ueMsg->msg.ueUetServiceReq.rrcCause;
+   Bool noMac = p_ueMsg->msg.ueUetServiceReq.noMac;
    ret = ueDbmFetchUe(ueId, (PTR *)&ueCb);
    if( ret != ROK )
    {
@@ -5112,7 +5117,7 @@ PRIVATE S16 ueProcUeServiceRequest
    {
       mTmsi = ueCb->ueCtxt.ueGuti.mTMSI;
    }
-   ret = ueSendServiceRequest(ueCb, mTmsi, rrcCause);
+   ret = ueSendServiceRequest(ueCb, mTmsi, rrcCause, noMac);
    if (ret != ROK)
    {
       UE_LOG_ERROR(ueAppCb, "Sending Service Request message failed");

--- a/TestCntlrApp/src/ueApp/ue_app_sec.c
+++ b/TestCntlrApp/src/ueApp/ue_app_sec.c
@@ -634,6 +634,11 @@ UeAppMsg       *dstMsg;
       UE_APP_SEC_PRNT_ERR(("Invalid Sequnce Number"));
       RETVALUE(RFAILED);
    }
+
+   if (secCtx->noMac) {
+     mac = 0;
+     secCtx->noMac = FALSE;
+   }
    /*Last 2 bytes of MAC is Short MAC*/
    msg[2] = (U8)((mac>>8) & 0xFF);
    msg[3] = (U8)((mac) & 0xFF);

--- a/TestCntlrApp/src/ueApp/ue_app_sec.x
+++ b/TestCntlrApp/src/ueApp/ue_app_sec.x
@@ -141,6 +141,7 @@ typedef struct ueAppSecCtxtCb
    /*Local Info*/
    UeAppNasSeqNmb  dlSeqNmb;
    UeAppNasSeqNmb  ulSeqNmb;
+   Bool            noMac;
 }UeAppSecCtxtCb;
 
 /*Key Generation Interface in MME*/


### PR DESCRIPTION
…value

Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

## Title
[new scenario] Simulate sending of service req with zero mac

## Summary
This PR contains code changes to send service request message with mac value as 0. MME does not find the UE context after receiving this message and triggers service reject with cause "UE context not found"

## Test plan
- Verified TC in magma PR - https://github.com/magma/magma/pull/3924
- Verified sanity
