### PR TITLE
[Bug_Fix] [Stateless_Testing] Fixed issues with NW initiated detach not handled for stateless ics drop test cases

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1102,20 +1102,28 @@ PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail)
  * @return  S16
  *          -# Success : ROK
  */
-PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup)
-{
-   NB_LOG_ENTERFN(&nbCb);
+PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup) {
+  NB_LOG_ENTERFN(&nbCb);
 
-   if(NULLP == dropInitCtxtSetup)
-   {
-      NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
-      RETVALUE(RFAILED);
-   }
+  if (NULLP == dropInitCtxtSetup) {
+    NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+    RETVALUE(RFAILED);
+  }
 
-   nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable = dropInitCtxtSetup->isDropICSEnable;
-   nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].tmrVal = dropInitCtxtSetup->tmrVal;
+  nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable =
+      dropInitCtxtSetup->isDropICSEnable;
+  nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].tmrVal =
+      dropInitCtxtSetup->tmrVal;
 
-   RETVALUE(ROK);
+  if ((nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable ==
+       FALSE) &&
+      (nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isICSReqDropped ==
+       TRUE)) {
+    nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isICSReqDropped =
+        FALSE;
+  }
+
+  RETVALUE(ROK);
 }
 
 /*

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1093,7 +1093,7 @@ PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail)
 }
 
 /*
- * @details This function marked a ue for dropping intial context setup
+ * @details This function marks a ue for dropping intial context setup
  *
  * Function: NbEnbDropInitCtxtSetup
  *
@@ -1112,25 +1112,27 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup) {
 
   nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable =
       dropInitCtxtSetup->isDropICSEnable;
-  nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].tmrVal =
-      dropInitCtxtSetup->tmrVal;
 
-  if ((nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isDropICSEnable ==
-       FALSE) &&
-      (nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isICSReqDropped ==
-       TRUE)) {
-    nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isICSReqDropped =
-        FALSE;
+  if (dropInitCtxtSetup->isDropICSEnable == TRUE) {
+    nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].tmrVal =
+        dropInitCtxtSetup->tmrVal;
 
-    NbUeCb *ueCb = NULLP;
-    if (ROK !=
-        (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(dropInitCtxtSetup->ueId),
-                        sizeof(U32), 0, (PTR *)&ueCb))) {
-      NB_LOG_ERROR(&nbCb, "Failed to stop the local UE context release timer, "
-                          "could not find ueCb");
-      RETVALUE(RFAILED);
-    } else {
-      nbStopTmr((PTR)ueCb, NB_TMR_LCL_UE_CTXT_REL_REQ);
+  } else {
+    // Stop local UE context release timer if it is running
+    if (nbIsTmrRunning(
+            &nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].timer,
+            NB_TMR_LCL_UE_CTXT_REL_REQ)) {
+      NbUeCb *ueCb = NULLP;
+      if (ROK !=
+          (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(dropInitCtxtSetup->ueId),
+                          sizeof(U32), 0, (PTR *)&ueCb))) {
+        NB_LOG_ERROR(&nbCb,
+                     "Failed to stop the local UE context release timer, "
+                     "could not find ueCb");
+        RETVALUE(RFAILED);
+      } else {
+        nbStopTmr((PTR)ueCb, NB_TMR_LCL_UE_CTXT_REL_REQ);
+      }
     }
   }
 

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1106,7 +1106,7 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup) {
   NB_LOG_ENTERFN(&nbCb);
 
   if (NULLP == dropInitCtxtSetup) {
-    NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+    NB_LOG_ERROR(&nbCb, "Received empty(NULL) request");
     RETVALUE(RFAILED);
   }
 

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -1121,6 +1121,17 @@ PUBLIC S16 NbEnbDropInitCtxtSetup(NbDropInitCtxtSetup *dropInitCtxtSetup) {
        TRUE)) {
     nbCb.dropInitCtxtSetup[(dropInitCtxtSetup->ueId) - 1].isICSReqDropped =
         FALSE;
+
+    NbUeCb *ueCb = NULLP;
+    if (ROK !=
+        (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(dropInitCtxtSetup->ueId),
+                        sizeof(U32), 0, (PTR *)&ueCb))) {
+      NB_LOG_ERROR(&nbCb, "Failed to stop the local UE context release timer, "
+                          "could not find ueCb");
+      RETVALUE(RFAILED);
+    } else {
+      nbStopTmr((PTR)ueCb, NB_TMR_LCL_UE_CTXT_REL_REQ);
+    }
   }
 
   RETVALUE(ROK);

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2353,6 +2353,7 @@ PUBLIC S16 nbPrcIncS1apMsg(NbUeCb *ueCb, S1apPdu *pdu, U8 msgType)
       }
       else
       {
+         NB_LOG_DEBUG(&nbCb, "Dropping incoming DL-NAS message as ICS drop is enabled");
          ret = ROK; /* drop the all incoming DL-NAS messages if the drop ICS is enabled */
       }
    }

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2254,7 +2254,7 @@ PRIVATE S16 nbHandleInitCtxtPrcSetup(NbUeCb *ueCb, S1apPdu *pdu) {
         NB_FREE(erabInfo, sizeof(NbErabLst));
       } else {
         retVal = nbSendErabsInfo(ueCb, erabInfo, NULL, ueRadCapRcvd);
-        // do the ip-query  ueapp for received bearers
+        // Do the IP-query to ueapp for received bearers
         for (idx = 0; idx < erabInfo->noOfComp; idx++) {
           nbHandleUeIpInfoReq(ueCb->ueId, erabInfo->erabs[idx].erabId);
         }
@@ -2403,7 +2403,7 @@ PUBLIC S16 nbPrcIncS1apMsg(NbUeCb *ueCb, S1apPdu *pdu, U8 msgType) {
                  "nbPrcIncS1apMsg(): Handling RAB Release Command message\n");
     ret = nbProcErabRelCmd(pdu, ueCb);
     if (ret != ROK) {
-      NB_LOG_ERROR(&nbCb, "Failed to Send Erab Release command Indiaction "
+      NB_LOG_ERROR(&nbCb, "Failed to send Erab Release Command Indication "
                           "to ueApp");
     }
 

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2093,7 +2093,7 @@ PRIVATE S16 nbHandleInitCtxtPrcSetup(NbUeCb *ueCb, S1apPdu *pdu) {
   SztE_RABToBeSetupLstCtxtSUReq *s1ErabLst = NULLP;
   Bool ueRadCapRcvd = FALSE;
 
-  /* Parse and process the received IEs */
+  // Parse and process the received IEs
   initMsg = &(pdu->pdu.val.initiatingMsg);
   protIes = &initMsg->value.u.sztInitCntxtSetupRqst.protocolIEs;
 
@@ -2183,28 +2183,28 @@ PRIVATE S16 nbHandleInitCtxtPrcSetup(NbUeCb *ueCb, S1apPdu *pdu) {
       if (ROK != sendInitCtxtSetupFailRsp(ueCb, &cause)) {
         NB_LOG_DEBUG(
             &nbCb,
-            "Failed to Sending Initial Context Setup Failure message to MME");
+            "Failed to send Initial Context Setup Failure message to MME");
       }
       NB_FREE(erabInfo->erabs, (erabInfo->noOfComp * sizeof(NbErabCb)));
       NB_FREE(erabInfo, sizeof(NbErabLst));
     } else if (nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isDropICSEnable ==
                TRUE) {
-      if (nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isICSReqDropped == FALSE) {
-        nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isICSReqDropped = TRUE;
-        /* start timr to release the UE context locally */
+      if (!nbIsTmrRunning(&nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].timer,
+                          NB_TMR_LCL_UE_CTXT_REL_REQ)) {
+        // Start timer to release the UE context locally
         cmInitTimers(&nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].timer, 1);
         if (retVal !=
             nbStartTmr((PTR)ueCb, NB_TMR_LCL_UE_CTXT_REL_REQ,
                        nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].tmrVal)) {
           RETVALUE(retVal);
         }
-        /* send indication to tfwApp for dropping the Initial Context Setup Req
-         */
-        retVal = nbUiSendIntCtxtSetupDrpdIndToUser(ueCb->ueId);
-        if (retVal != ROK) {
-          NB_LOG_ERROR(&nbCb, "Failed to Send Initial Context Setup"
-                              "Dropped Indiaction to User");
-        }
+      }
+
+      // Send indication to tfwApp for dropping the Initial Context Setup Req
+      retVal = nbUiSendIntCtxtSetupDrpdIndToUser(ueCb->ueId);
+      if (retVal != ROK) {
+        NB_LOG_ERROR(&nbCb, "Failed to send Initial Context Setup Dropped "
+                            "Indiaction to User");
       }
       NB_FREE(erabInfo->erabs, (erabInfo->noOfComp * sizeof(NbErabCb)));
       NB_FREE(erabInfo, sizeof(NbErabLst));
@@ -2215,7 +2215,7 @@ PRIVATE S16 nbHandleInitCtxtPrcSetup(NbUeCb *ueCb, S1apPdu *pdu) {
       NB_FREE(erabInfo, sizeof(NbErabLst));
     } else {
       if (nbCb.delayInitCtxtSetupRsp[(ueCb->ueId) - 1].delayICSRsp != TRUE) {
-        /* send the s1-context resp to mme and nas pdu to ue */
+        // Send the s1-context resp to mme and nas pdu to UE
         retVal = nbBuildAndSendIntCtxtSetupRsp(ueCb, erabInfo);
         if (retVal != ROK) {
           NB_FREE(erabInfo->erabs, (erabInfo->noOfComp * sizeof(NbErabCb)));
@@ -2254,7 +2254,7 @@ PRIVATE S16 nbHandleInitCtxtPrcSetup(NbUeCb *ueCb, S1apPdu *pdu) {
         NB_FREE(erabInfo, sizeof(NbErabLst));
       } else {
         retVal = nbSendErabsInfo(ueCb, erabInfo, NULL, ueRadCapRcvd);
-        /* do the ip-query  ueapp for received bearers */
+        // do the ip-query  ueapp for received bearers
         for (idx = 0; idx < erabInfo->noOfComp; idx++) {
           nbHandleUeIpInfoReq(ueCb->ueId, erabInfo->erabs[idx].erabId);
         }
@@ -2338,92 +2338,91 @@ PRIVATE S16 nbHandleRabSetupMsg(NbUeCb *ueCb, S1apPdu *pdu) {
   -# Failure : RFAILED
 */
 
+PUBLIC S16 nbPrcIncS1apMsg(NbUeCb *ueCb, S1apPdu *pdu, U8 msgType) {
+  U32 procedureCodeVal;
+  U8 ret = RFAILED;
+  // Get the procedure code
+  procedureCodeVal = pdu->pdu.val.initiatingMsg.procedureCode.val;
+  if (procedureCodeVal == 11) // downlink NAS Transport MSG
+  {
+    ret = nbProcessDlNasMsg(ueCb, pdu, msgType);
+  } else if (procedureCodeVal == 9) // initial context setup request
+  {
+    ret = nbHandleInitCtxtPrcSetup(ueCb, pdu);
+    // Inform the Tfw about Initial Context Setup
+    if ((nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isDropICSEnable != TRUE) &&
+        (nbCb.dropICSSndCtxtRel[(ueCb->ueId) - 1].sndICSRspUeCtxtRel != TRUE)) {
+      ret = nbUiSendIntCtxtSetupIndToUser(
+          ueCb->ueId,
+          nbCb.initCtxtSetupFail[(ueCb->ueId) - 1].initCtxtSetupFailInd);
+      if (ret != ROK) {
+        NB_LOG_ERROR(&nbCb, "Failed to Send Initial Context Setup"
+                            "Indiaction to ueApp");
+      }
+    }
+  } else if (procedureCodeVal == 5) // rab setup request
+  {
+    NB_LOG_DEBUG(&nbCb,
+                 "nbPrcIncS1apMsg(): Handling RAB Setup Request message\n");
+    ret = nbHandleRabSetupMsg(ueCb, pdu);
+  } else if (procedureCodeVal == 23) // context release command message
+  {
+    ret = nbHandleS1UeReleaseCmd(ueCb);
+    if (ret == ROK) {
+      // Inform the ueApp about UE context release
+      ret = nbSendS1RelIndToUeApp(ueCb->ueId);
+      if (ret != ROK) {
+        NB_LOG_ERROR(&nbCb, "Failed to Send S1 Release Indiaction "
+                            "to ueApp");
+      }
 
-PUBLIC S16 nbPrcIncS1apMsg(NbUeCb *ueCb, S1apPdu *pdu, U8 msgType)
-{
-   U32 procedureCodeVal;
-   U8 ret = RFAILED;
-   /* get the procedure code */
-   procedureCodeVal = pdu->pdu.val.initiatingMsg.procedureCode.val;
-   if(procedureCodeVal == 11) /* downlink NAS Transport MSG */
-   {
-      if(nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isICSReqDropped  != TRUE )
-      {
-         ret = nbProcessDlNasMsg(ueCb, pdu, msgType);
+      if (nbIsTmrRunning(&nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].timer,
+                         NB_TMR_LCL_UE_CTXT_REL_REQ)) {
+        nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isDropICSEnable = FALSE;
+
+        if (ROK != (cmHashListFind(&(nbCb.ueCbLst), (U8 *)&(ueCb->ueId),
+                                   sizeof(U32), 0, (PTR *)&ueCb))) {
+          NB_LOG_ERROR(&nbCb,
+                       "Failed to stop the local UE context release timer, "
+                       "could not find ueCb");
+          RETVALUE(RFAILED);
+        } else {
+          nbStopTmr((PTR)ueCb, NB_TMR_LCL_UE_CTXT_REL_REQ);
+        }
       }
-      else
-      {
-         NB_LOG_DEBUG(&nbCb, "Dropping incoming DL-NAS message as ICS drop is enabled");
-         ret = ROK; /* drop the all incoming DL-NAS messages if the drop ICS is enabled */
-      }
-   }
-   else if(procedureCodeVal == 9) /* initial context setup request*/
-   {
-      ret = nbHandleInitCtxtPrcSetup(ueCb,pdu);
-      /* Inform the Tfw about Initial Context Setup */
-      if((nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].isDropICSEnable != TRUE) &&\
-             (nbCb.dropICSSndCtxtRel[(ueCb->ueId) - 1].sndICSRspUeCtxtRel != TRUE))
-      {
-         ret = nbUiSendIntCtxtSetupIndToUser(ueCb->ueId,\
-               nbCb.initCtxtSetupFail[(ueCb->ueId) - 1].initCtxtSetupFailInd);
-         if(ret != ROK)
-         {
-            NB_LOG_ERROR(&nbCb, "Failed to Send Initial Context Setup"\
-                                 "Indiaction to ueApp");
-          }
-      }
-   }
-   else if(procedureCodeVal == 5 ) /* rab setup request */
-   {
-      NB_LOG_DEBUG(&nbCb,"nbPrcIncS1apMsg(): Handling RAB Setup Request message\n");
-      ret = nbHandleRabSetupMsg(ueCb,pdu);
-   }
-   else if(procedureCodeVal == 23) /* context release command message */
-   {
-      ret = nbHandleS1UeReleaseCmd(ueCb);
-      if(ret == ROK)
-      {
-         /* Inform the ueApp about UE context release */
-         ret = nbSendS1RelIndToUeApp(ueCb->ueId);
-         if(ret != ROK)
-         {
-            NB_LOG_ERROR(&nbCb, "Failed to Send S1 Release Indiaction "\
-                  "to ueApp");
-         }
- #if 0
+#if 0
 
          /* Inform the Tfw about UE context release */
          ret = nbUiSendUeCtxRelIndToUser(ueCb->ueId);
          /* trigger ueCb deletion in enbApp */
          ret = nbIfmDamUeDelReq(ueCb->ueId);
 #endif
-      }
-   } else if (procedureCodeVal == 7 ) {
-      NB_LOG_DEBUG(&nbCb,"nbPrcIncS1apMsg(): Handling RAB Release Command message\n");
-      ret = nbProcErabRelCmd(pdu, ueCb);
-      if(ret != ROK)
-      {
-        NB_LOG_ERROR(&nbCb, "Failed to Send Erab Release command Indiaction "\
-             "to ueApp");
-      }
+    }
+  } else if (procedureCodeVal == 7) {
+    NB_LOG_DEBUG(&nbCb,
+                 "nbPrcIncS1apMsg(): Handling RAB Release Command message\n");
+    ret = nbProcErabRelCmd(pdu, ueCb);
+    if (ret != ROK) {
+      NB_LOG_ERROR(&nbCb, "Failed to Send Erab Release command Indiaction "
+                          "to ueApp");
+    }
 
-   }
+  }
 #ifdef MULTI_ENB_SUPPORT
-   else if (procedureCodeVal == 3)/* Path SW Req Ack*/
-   {
-     NB_LOG_DEBUG(&nbCb, "RECEIVED PATH SW REQ ACK");
-     ret = nbPrcPathSwReqAck(ueCb, pdu);
-   }
+  else if (procedureCodeVal == 3) // Path SW Req Ack
+  {
+    NB_LOG_DEBUG(&nbCb, "RECEIVED PATH SW REQ ACK");
+    ret = nbPrcPathSwReqAck(ueCb, pdu);
+  }
 #endif
-   else
-   {
-      NB_LOG_ERROR(&nbCb, "Procedure not handled");
-      ret = RFAILED;
-   }
+  else {
+    NB_LOG_ERROR(&nbCb, "Procedure not handled");
+    ret = RFAILED;
+  }
 
-   cmFreeMem((Ptr *)(pdu));
+  cmFreeMem((Ptr *)(pdu));
 
-   RETVALUE(ret);
+  RETVALUE(ret);
 }
 
 PUBLIC S16 nbPrcS1apRelInd

--- a/TestCntlrApp/src/enbApp/nb_tmr.c
+++ b/TestCntlrApp/src/enbApp/nb_tmr.c
@@ -233,11 +233,11 @@ U32                          delay
  *     Function: nbStopTmr
  *
  *         Processing steps:
- *               This function based upon the timer event reterives relevant
+ *               This function based upon the timer event retrieves relevant
  *               timerCb and tries to determine whether timer is running or
- *               not.In case timer was running, it is stopped .
+ *               not. In case timer was running, it is stopped.
  *
- * @param[in] Cb : This holds approriate Control block for the timer event
+ * @param[in] Cb : This holds appropriate Control block for the timer event
  *                 passed.
  * @param[in] tmrEvent : One of the many possible timer types.
  * @return S16

--- a/TestCntlrApp/src/enbApp/nb_tmr.c
+++ b/TestCntlrApp/src/enbApp/nb_tmr.c
@@ -226,109 +226,105 @@ U32                          delay
    RETVALUE(ROK);
 } /* end of nbStartTmr() */
 
-
-/** @brief This function is used to stop a previously running timer. 
+/** @brief This function is used to stop a previously running timer.
  *
  * @details
  *
  *     Function: nbStopTmr
  *
  *         Processing steps:
- *               This function based upon the timer event reterives relevant timerCb and 
- *               tries to determine whether timer is running or not.In case timer 
- *               was running, it is stopped .
+ *               This function based upon the timer event reterives relevant
+ *               timerCb and tries to determine whether timer is running or
+ *               not.In case timer was running, it is stopped .
  *
- * @param[in] Cb : This holds approriate Control block for the timer event passed. 
- * @param[in] tmrEvent : One of the many possible timer types. 
+ * @param[in] Cb : This holds approriate Control block for the timer event
+ *                 passed.
+ * @param[in] tmrEvent : One of the many possible timer types.
  * @return S16
  *        -# Success : ROK
  *        -# Failure : RFAILED
  */
-PUBLIC Void nbStopTmr
-(
-PTR                          cb,
-S16                          event
-)
-{
-   CmTmrArg                  arg;
-   U8                        idx;
-   Bool                      tmrRunning;
-   CmTimer                   *timers = NULLP;
-   U8                        max = 0;
-   NbLiSapCb                 *sapCb;
-   NbRouterSolicitCb         *rsCb = NULLP;
+PUBLIC Void nbStopTmr(PTR cb, S16 event) {
+  CmTmrArg arg;
+  U8 idx;
+  Bool tmrRunning;
+  CmTimer *timers = NULLP;
+  U8 max = 0;
+  NbLiSapCb *sapCb;
+  NbRouterSolicitCb *rsCb = NULLP;
 
-   idx = 0;
+  idx = 0;
 
-   tmrRunning = FALSE;
-   switch(event)
-   {
-      case NB_TMR_SZT_SAP_BND:
-      case NB_TMR_EGT_SAP_BND:
-      {
-         sapCb = (NbLiSapCb*)cb;
-         max     =  1;
-         if(sapCb->timer.tmrEvnt == event)
-         {
-            tmrRunning = TRUE;
-            sapCb->bndRetryCnt = 0;
-         }
-         timers = &sapCb->timer;
-         break;
-      }
-      case NB_TMR_MME_SETUP_RSP:
-      {
-         NbMmeCb             *mmeCb = (NbMmeCb *)cb;
-         timers = &mmeCb->timer;
-         max    = 1;
-         if (mmeCb->timer.tmrEvnt == event)
-         {
-            tmrRunning = TRUE;
-         }
-         break;
-      }
-      case NB_TMR_MME_SETUP_WAIT:
-      {
-         NbMmeCb             *mmeCb = (NbMmeCb *)cb;
-         timers = &mmeCb->timer;
-         max    = 1;
-         if (mmeCb->timer.tmrEvnt == event)
-         {
-            tmrRunning = TRUE;
-         }
-         break;
-      }
-      case NB_TMR_ROUTER_SOLICIT: {
-        rsCb = (NbRouterSolicitCb *)cb;
-        nbCb.rsCb[(rsCb->ueId)-1] = rsCb;
-        timers = &nbCb.rsCb[(rsCb->ueId)-1]->timer;
-        max = 1;
-        if (nbCb.rsCb[(rsCb->ueId)-1]->timer.tmrEvnt == event) {
-          tmrRunning = TRUE;
-        }
-        break;
-      }
+  tmrRunning = FALSE;
+  switch (event) {
+  case NB_TMR_SZT_SAP_BND:
+  case NB_TMR_EGT_SAP_BND: {
+    sapCb = (NbLiSapCb *)cb;
+    max = 1;
+    if (sapCb->timer.tmrEvnt == event) {
+      tmrRunning = TRUE;
+      sapCb->bndRetryCnt = 0;
+    }
+    timers = &sapCb->timer;
+    break;
+  }
+  case NB_TMR_MME_SETUP_RSP: {
+    NbMmeCb *mmeCb = (NbMmeCb *)cb;
+    timers = &mmeCb->timer;
+    max = 1;
+    if (mmeCb->timer.tmrEvnt == event) {
+      tmrRunning = TRUE;
+    }
+    break;
+  }
+  case NB_TMR_MME_SETUP_WAIT: {
+    NbMmeCb *mmeCb = (NbMmeCb *)cb;
+    timers = &mmeCb->timer;
+    max = 1;
+    if (mmeCb->timer.tmrEvnt == event) {
+      tmrRunning = TRUE;
+    }
+    break;
+  }
+  case NB_TMR_LCL_UE_CTXT_REL_REQ: {
+    NbUeCb *ueCb = (NbUeCb *)cb;
+    timers = &nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].timer;
+    max = 1;
+    if (nbCb.dropInitCtxtSetup[(ueCb->ueId) - 1].timer.tmrEvnt == event) {
+      tmrRunning = TRUE;
+    }
+    break;
+  }
+  case NB_TMR_ROUTER_SOLICIT: {
+    rsCb = (NbRouterSolicitCb *)cb;
+    nbCb.rsCb[(rsCb->ueId) - 1] = rsCb;
+    timers = &nbCb.rsCb[(rsCb->ueId) - 1]->timer;
+    max = 1;
+    if (nbCb.rsCb[(rsCb->ueId) - 1]->timer.tmrEvnt == event) {
+      tmrRunning = TRUE;
+    }
+    break;
+  }
 
-      default:
-         break;
-   }
-   if(tmrRunning == FALSE)
-   {
-      RETVOID;
-   }
+  default:
+    break;
+  }
+  if (tmrRunning == FALSE) {
+    RETVOID;
+  }
 
-   /* initialize argument for common timer function */
-   arg.tqCp    = &nbCb.tqCp;
-   arg.tq      = nbCb.tq; 
-   arg.timers  = timers;
-   arg.cb      = cb;
-   arg.evnt    = event;
-   arg.wait    = 0;
-   arg.max     = max;
-   arg.tNum    = idx;
-   cmRmvCbTq(&arg);
+  /* initialize argument for common timer function */
+  arg.tqCp = &nbCb.tqCp;
+  arg.tq = nbCb.tq;
+  arg.timers = timers;
+  arg.cb = cb;
+  arg.evnt = event;
+  arg.wait = 0;
+  arg.max = max;
+  arg.tNum = idx;
+  cmRmvCbTq(&arg);
 
-   RETVOID;
+  RETVOID;
 } /* end of nbStopTmr() */
 
 


### PR DESCRIPTION
## Title
[Bug_Fix] [Stateless_Testing] Fixed issues with nw initiated detach not handled for stateless ics drop test cases

## Summary
The NW Initiated detach requests were getting dropped for test case "s1aptests/test_attach_ics_drop_with_mme_restart.py". The reason was that the ICS req dropped flag was not getting reset from test script and hence for any new DL request, the message was getting dropped. This PR fixes the issue.

## Test Plan
Verified with Sanity and individual test case executions