### PR TITLE
[s1 sim][new feature] IMEI restriction support

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -26,7 +26,7 @@ extern "C" {
 #endif   /* __cplusplus  */
 
 #define UE_IMSI_LENGTH 15
-#define UE_IMEI_LENGTH 16
+#define UE_IMEISV_LENGTH 16
 #define CM_EMM_MAX_MOBILE_ID_DIGS 15
 #define MAX_APN_LEN 50
 #define OP_KEY_LEN 16
@@ -410,7 +410,7 @@ typedef struct _ueUetSecModeComplete
 {
    U32 ueId;
    Bool imeisvPres;
-   U8 imeisv[UE_IMEI_LENGTH];
+   U8 imeisv[UE_IMEISV_LENGTH];
 }UeUetSecModeComplete;
 
 typedef struct _ueUetSecModeReject

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -357,10 +357,14 @@ typedef struct _ueUetIdentReqInd
    U8 idType;
 }UeUetIdentReqInd;
 
-typedef struct _ueUetIdentRsp
-{
-   U32 ueId;
-   U8 idType;
+typedef struct _ueUetIdentRsp {
+  U32 ueId;
+  U8 idType;
+  Bool idValPres;
+  /* As of now we consider only IMSI/IMEI/IMEISV
+   * so UE_IMEISV_LENGTH=16 should be sufficient
+   */
+  U8 idVal[UE_IMEISV_LENGTH];
 }UeUetIdentRsp;
 
 typedef struct _ueUetAuthReqInd
@@ -412,6 +416,7 @@ typedef struct _ueUetSecModeComplete
 {
    U32 ueId;
    Bool imeisvPres;
+   Bool noImeisv;
    U8 imeisv[UE_IMEISV_LENGTH];
 }UeUetSecModeComplete;
 

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -412,12 +412,19 @@ typedef struct _ueUetSecModeCmdInd
    U8 KNasVrfySts;
 }UeUetSecModeCmdInd;
 
-typedef struct _ueUetSecModeComplete
-{
-   U32 ueId;
-   Bool imeisvPres;
-   Bool noImeisv;
-   U8 imeisv[UE_IMEISV_LENGTH];
+typedef struct _ueUetSecModeComplete {
+  U32 ueId;
+  /* Flag to indicate if the imeisv
+   * value provided in the test to be
+   * used or it should be taken from
+   * ueCb
+   */
+  Bool imeisvPres;
+  /* Flag to indicate if imeisv should
+   * be included in the msg or not
+   */
+  Bool noImeisv;
+  U8 imeisv[UE_IMEISV_LENGTH];
 }UeUetSecModeComplete;
 
 typedef struct _ueUetSecModeReject

--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -26,6 +26,7 @@ extern "C" {
 #endif   /* __cplusplus  */
 
 #define UE_IMSI_LENGTH 15
+#define UE_IMEI_LENGTH 16
 #define CM_EMM_MAX_MOBILE_ID_DIGS 15
 #define MAX_APN_LEN 50
 #define OP_KEY_LEN 16
@@ -408,6 +409,8 @@ typedef struct _ueUetSecModeCmdInd
 typedef struct _ueUetSecModeComplete
 {
    U32 ueId;
+   Bool imeisvPres;
+   U8 imeisv[UE_IMEI_LENGTH];
 }UeUetSecModeComplete;
 
 typedef struct _ueUetSecModeReject

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -448,9 +448,13 @@ PUBLIC S16 handlSecModComp(ueSecModeComplete_t *data)
    FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
    uetMsg->msgType = UE_SEC_MOD_CMP_TYPE;
    ueSecModComp = &uetMsg->msg.ueUetSecModeComplete;
+   cmMemset((U8 *)ueSecModComp, 0, sizeof(UeUetSecModeComplete));
 
    ueSecModComp->ueId = data->ue_Id;
-
+   ueSecModComp->imeisvPres = data->imeisv_pres;
+   if (ueSecModComp->imeisvPres) {
+     cmMemcpy(ueSecModComp->imeisv, data->imeisv, FW_MAX_IMEISV_LEN);
+   }
    fwSendToUeApp(uetMsg);
    FW_LOG_EXITFN(fwCb, ROK);
 }

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -406,21 +406,25 @@ PUBLIC S16 handleActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data)
  *   File:  fw_api_int.c
  *
  */
-PUBLIC S16 handlIdentResp(ueIdentityResp_t *data)
-{
-   FwCb *fwCb = NULLP;
-   UetMessage *uetMsg = NULLP;
+PUBLIC S16 handlIdentResp(ueIdentityResp_t *data) {
+  FwCb *fwCb = NULLP;
+  UetMessage *uetMsg = NULLP;
 
-   FW_GET_CB(fwCb);
-   FW_LOG_ENTERFN(fwCb);
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
 
-   FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
-   uetMsg->msgType = UE_IDENTITY_RES_TYPE;
+  FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+  uetMsg->msgType = UE_IDENTITY_RES_TYPE;
 
-   uetMsg->msg.ueUetIdentRsp.ueId = data->ue_Id;
-   uetMsg->msg.ueUetIdentRsp.idType = data->idType;
+  uetMsg->msg.ueUetIdentRsp.ueId = data->ue_Id;
+  uetMsg->msg.ueUetIdentRsp.idType = data->idType;
+  uetMsg->msg.ueUetIdentRsp.idValPres = data->idValPres;
+  if (data->idValPres) {
+    cmMemcpy(uetMsg->msg.ueUetIdentRsp.idVal, data->idVal,
+       sizeof(data->idVal));
+  }
 
-   fwSendToUeApp(uetMsg);
+  fwSendToUeApp(uetMsg);
 
    RETVALUE(ROK);
 }
@@ -454,6 +458,7 @@ PUBLIC S16 handlSecModComp(ueSecModeComplete_t *data)
 
    ueSecModComp->ueId = data->ue_Id;
    ueSecModComp->imeisvPres = data->imeisv_pres;
+   ueSecModComp->noImeisv = data->noImeisv;
    if (ueSecModComp->imeisvPres) {
      cmMemcpy(ueSecModComp->imeisv, data->imeisv, FW_MAX_IMEISV_LEN);
    }

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -31,6 +31,7 @@ extern "C" {
 /* EMM Cause Values */
 #define TFW_EMM_CAUSE_IMSI_UNKNOWN                    0x02
 #define TFW_EMM_CAUSE_ILLEGAL_UE                      0x03
+#define TFW_EMM_CAUSE_IMEI_NOT_ACCEPTED               0x05
 #define TFW_EMM_CAUSE_ILLEGAL_ME                      0x06
 #define TFW_EMM_CAUSE_EPS_SVC_NA                      0x07
 #define TFW_EMM_CAUSE_NON_EPS_SVC_NA                  0x08

--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -104,6 +104,7 @@ extern "C" {
 // Authentication failure param AUTS length
 #define TFW_AUTS_LEN 14
 #define MAX_FAILED_ERABS 11
+#define FW_MAX_IMEISV_LEN 16
 #ifdef TFW_STUB /* definitions only required by test controller */
 
 /* Mobile Identity types */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -771,9 +771,10 @@ typedef struct ueSecModeCmdInd
    U8 knas_Vrfy_Sts;
 }ueSecModeCmdInd_t;
 
-typedef struct ueSecModeComplete
-{
-   U32 ue_Id;
+typedef struct ueSecModeComplete {
+  U32 ue_Id;
+  Bool imeisv_pres;
+  U8 imeisv[FW_MAX_IMEISV_LEN];
 }ueSecModeComplete_t;
 
 typedef struct ueSecModeReject

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -775,7 +775,7 @@ typedef struct ueSecModeComplete {
   U32 ue_Id;
   Bool imeisv_pres;
   U8 imeisv[FW_MAX_IMEISV_LEN];
-}ueSecModeComplete_t;
+} ueSecModeComplete_t;
 
 typedef struct ueSecModeReject
 {

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -776,7 +776,14 @@ typedef struct ueSecModeCmdInd
 
 typedef struct ueSecModeComplete {
   U32 ue_Id;
+  /* Flag to indiciate if imeisv value is
+   * provided from the test
+   */
   Bool imeisv_pres;
+  /* Flag to indiciate if imeisv should
+   * be included in security mode complete msg
+   */
+  Bool noImeisv;
   U8 imeisv[FW_MAX_IMEISV_LEN];
 } ueSecModeComplete_t;
 
@@ -1039,16 +1046,20 @@ typedef struct ueAttachRejInd
    U8 cause;
 }ueAttachRejInd_t;
 
-typedef struct ueIdentityReqInd
-{
-   U32 ue_Id;
-   U8 idType;
+typedef struct ueIdentityReqInd {
+  U32 ue_Id;
+  U8 idType;
 }ueIdentityReqInd_t;
 
-typedef struct ueIdentityResp
-{
-   U32 ue_Id;
-   U8 idType;
+typedef struct ueIdentityResp {
+  U32 ue_Id;
+  U8 idType;
+  Bool idValPres;
+  /* As of now we consider only IMSI/IMEI/IMEISV
+   * so FW_MAX_IMEISV_LEN=16 should be sufficient
+   */
+  U8 idVal[FW_MAX_IMEISV_LEN];
+
 }ueIdentityResp_t;
 
 typedef struct ueTauReq

--- a/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
+++ b/TestCntlrApp/src/tfwApp/fw_uemsg_handler.c
@@ -677,6 +677,7 @@ PUBLIC S16 ueSecModCmdInd
       {
          ueSecModeComplete_t *secModComp = NULLP;
          FW_ALLOC_MEM(fwCb, &secModComp, sizeof(ueSecModeComplete_t));
+         cmMemset((U8*)secModComp, 0, sizeof(ueSecModeComplete_t));
          secModComp->ue_Id = uetSecModCmdInd->msg.ueUetSecModeCmdInd.ueId;
          handlSecModComp(secModComp);
          ueIdCb->state = UE_SEC_MOD_COMPLETE_DONE;

--- a/TestCntlrApp/src/ueApp/ueAppdbm.x
+++ b/TestCntlrApp/src/ueApp/ueAppdbm.x
@@ -185,6 +185,7 @@ typedef struct ueAppInfo
    U8            imsiLen;    /* len of IMSI=MCC+MNC+MSIN */
    U8            ueImsi[CM_EMM_MAX_IMSI_DIGS]; /* IMSI of UE */
    U8            ueImei[CM_EMM_MAX_IMEI_DIGS]; /* Mobile equipment identity */
+   Bool          imeisvReq; // Flag set based on the req recvd in sec mode cmd
    GUTI          ueGuti;      /* Guti allocated to this UE from MME  */
    CmEmmTaiLst   *taList;     /* Tracking Area List for this UE from MME */
    CmEmmUeNwCap  ueNwCap;     /* Network capability of UE */

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -2679,6 +2679,8 @@ PRIVATE S16 ueAppUtlBldSecModComplete(UeCb *ueCb, UeUetSecModeComplete uetSmc, C
    (*ueEvt)->m.emmEvnt = emmMsg;
    secModeCmp = &((*ueEvt)->m.emmEvnt->u.secModCmp);
    if (ueCb->ueCtxt.imeisvReq) {
+     // Reset flag
+     ueCb->ueCtxt.imeisvReq = FALSE;
      UE_LOG_DEBUG(ueAppCb, "Filling IMEISV in security mode complete");
      secModeCmp->imeisv.pres = TRUE;
      secModeCmp->imeisv.type = CM_EMM_MID_TYPE_IMEISV;
@@ -2691,7 +2693,7 @@ PRIVATE S16 ueAppUtlBldSecModComplete(UeCb *ueCb, UeUetSecModeComplete uetSmc, C
        cmMemcpy((U8 *)&secModeCmp->imeisv.u.imei.id,
                 (U8 *)&ueCb->ueCtxt.ueImei, secModeCmp->imeisv.len);
      } else {
-       UE_LOG_DEBUG(ueAppCb, "Filling IMEISV from the data"
+       UE_LOG_DEBUG(ueAppCb, "Filling IMEISV"
                              "received from testscript");
        cmMemcpy((U8 *)&secModeCmp->imeisv.u.imei.id,
                 uetSmc.imeisv, secModeCmp->imeisv.len);

--- a/TestCntlrApp/src/ueApp/ue_emm_edm.c
+++ b/TestCntlrApp/src/ueApp/ue_emm_edm.c
@@ -521,7 +521,7 @@ CmEmmEdmMsgFormat emmMsgTab[CM_EMM_MAX_MSG][CM_EMM_MAX_IE] =
    /* Security Mode Complete */
    {
       { CM_EMM_IE_MSID, EDM_PRES_OPTIONAL, EDM_FMTTLV, TRUE, 0,
-         NULLP, NULLP, cmEmmDecMi}
+         NULLP, cmEmmEncMi, cmEmmDecMi}
    },
 
    /* Security Mode Reject */
@@ -2302,9 +2302,10 @@ U16 *len;
          break;
       }
       case CM_EMM_MID_TYPE_IMEI:
+      case CM_EMM_MID_TYPE_IMEISV:
       {
          /* encode type of ID */
-         buf[*indx] = CM_EMM_MID_TYPE_IMEI;
+         buf[*indx] = mi->type;
 
          /* encode even or odd indicator */
          buf[*indx] |= mi->evenOddInd << 3;


### PR DESCRIPTION
## Title
[s1 sim][new feature] IMEI restriction support

## Summary
This PR has the following support:
1.	Support to send imeisv in security mode complete and identity rsp messages
2.	Support to include imeisv value from the test script in security mode complete and identity rsp message

## Test plan
- Verified sanity
- Verified new TCs test_imei_restriction_smc.py and test_imei_restriction_no_imeisv_in_smc.py
