### PR TITLE
[error_ind_support] support to drop erab setup request

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -52,11 +52,11 @@ PUBLIC S16 NbEnbErabRelIndHdl(NbuErabRelIndList *erabRelInd);
 PUBLIC S16 NbEnbErabRelRspHdl(NbErabRelRsp *erabRelInd);
 PUBLIC S16 NbEnbNasNonDel(NbNasNonDel *nasNonDel);
 PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail);
+PUBLIC S16 NbHandleDropErabSetupReq(NbDropErabSetupReq *dropErabSetupReq);
 
 EXTERN S16 nbIfmDamTnlCreatReq(NbDamTnlInfo*);
 EXTERN S16 nbIfmDamUeRelReq(U32, U8);
 EXTERN S16 nbAppRouteInit(U32 selfIp, S8*);
-PUBLIC S16 NbEnbSendErrorInd(NbSendErrorInd*);
 
 EXTERN NbDamCb nbDamCb;
 
@@ -1708,24 +1708,22 @@ PUBLIC S16 NbEnbDropRA(NbDropRA *dropRA) {
   RETVALUE(ROK);
 }
 
-/*
- * @details This function marks a ue to send error indication
+/* @details This function marks a ue for dropping Erab Setup Request
  *
- * Function: NbEnbSendErrorInd
+ * Function: NbHandleDropErabSetupReq
  *
- *
- * @param[in]  NbSendErrorInd
+ * @param[in]  NbHandleDropErabSetupReq
  * @return  S16
  *          -# Success : ROK
  */
-PUBLIC S16 NbEnbSendErrorInd(NbSendErrorInd* sendErrInd) {
-  NB_LOG_ENTERFN(&nbCb);
+PUBLIC S16 NbHandleDropErabSetupReq(NbDropErabSetupReq *dropErabSetupReq) {
+   NB_LOG_ENTERFN(&nbCb);
 
-  if (NULLP == sendErrInd) {
-    NB_LOG_ERROR(&nbCb, "Received empty(NULL) request");
-    RETVALUE(RFAILED);
-  }
-  nbCb.sendErrorInd[(sendErrInd->ueId) - 1].isSendErrorInd =
-      sendErrInd->isSendErrorInd;
-  RETVALUE(ROK);
-}
+   if (NULLP == dropErabSetupReq) {
+     NB_LOG_ERROR(&nbCb, "Recieved empty(NULL) request");
+     RETVALUE(RFAILED);
+   }
+   nbCb.dropErabSetupReq[(dropErabSetupReq->ueId) - 1]
+       .isDropErabSetupReq = dropErabSetupReq->isDropErabSetupReqEnable;
+   RETVALUE(ROK);
+ }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -56,6 +56,7 @@ PUBLIC S16 NbEnbInitCtxtSetupFail(NbInitCtxtSetupFail *initCtxtSetupFail);
 EXTERN S16 nbIfmDamTnlCreatReq(NbDamTnlInfo*);
 EXTERN S16 nbIfmDamUeRelReq(U32, U8);
 EXTERN S16 nbAppRouteInit(U32 selfIp, S8*);
+PUBLIC S16 NbEnbSendErrorInd(NbSendErrorInd*);
 
 EXTERN NbDamCb nbDamCb;
 
@@ -1704,5 +1705,27 @@ PUBLIC S16 NbEnbDropRA(NbDropRA *dropRA) {
   NB_LOG_DEBUG(&nbCb, "Recieved an indication to Drop RA");
   nbCb.dropRA[(dropRA->ueId) - 1].isDropRA = dropRA->isDropRA;
 
+  RETVALUE(ROK);
+}
+
+/*
+ * @details This function marks a ue to send error indication
+ *
+ * Function: NbEnbSendErrorInd
+ *
+ *
+ * @param[in]  NbSendErrorInd
+ * @return  S16
+ *          -# Success : ROK
+ */
+PUBLIC S16 NbEnbSendErrorInd(NbSendErrorInd* sendErrInd) {
+  NB_LOG_ENTERFN(&nbCb);
+
+  if (NULLP == sendErrInd) {
+    NB_LOG_ERROR(&nbCb, "Received empty(NULL) request");
+    RETVALUE(RFAILED);
+  }
+  nbCb.sendErrorInd[(sendErrInd->ueId) - 1].isSendErrorInd =
+      sendErrInd->isSendErrorInd;
   RETVALUE(ROK);
 }

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -50,8 +50,8 @@ extern "C" {
 #include "gen.x"           /* General */
 #include "ssi.x"           /* System services */
 
-#include "cm_tkns.x"       /* Common tokens */
 #include "cm5.x"           /* Common timer library */
+#include "cm_tkns.x"       /* Common tokens */
 #include "cm_mblk.x"       /* Common memory allocation */
 #include "cm_llist.x"      /* Common link list */
 #include "cm_hash.x"       /* Common hashlist */
@@ -62,13 +62,11 @@ extern "C" {
 #include "hit.h"
 #include "sct.h"
 /* header include files related to lower layer interfaces */
-
 #include "szt.h"           /* S1AP RRM control Interface */
 #include "szt_asn.h"
 #include "nb_lnb.h"
 #include "egt.h"           /* DATA app, GTP interface   */
 #include "nbu.h"
-
 #ifdef SZTV3
 #include "szt_3gasn.h"
 #endif

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -483,6 +483,10 @@ typedef struct _dropRA {
   Bool isDropRA;
 } DropRA;
 
+typedef struct _sendErrorInd {
+  Bool isSendErrorInd;
+} SendErrorInd;
+
 typedef struct _nbRouterSolicitCb {
 #define NB_EGTP_MSG_SZ 1024
   U32 ueId;
@@ -535,6 +539,7 @@ typedef struct _nbCb
    DelayErabSetupRsp         delayErabSetupRsp[NB_MAX_UE_SUPPORTED];
    DropRA                       dropRA[NB_MAX_UE_SUPPORTED];
    NbRouterSolicitCb            *rsCb[NB_MAX_UE_SUPPORTED];
+   SendErrorInd              sendErrorInd[NB_MAX_UE_SUPPORTED];
 #ifdef MULTI_ENB_SUPPORT
    Bool                      x2HoDone;
 #endif

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -50,8 +50,8 @@ extern "C" {
 #include "gen.x"           /* General */
 #include "ssi.x"           /* System services */
 
-#include "cm5.x"           /* Common timer library */
 #include "cm_tkns.x"       /* Common tokens */
+#include "cm5.x"           /* Common timer library */
 #include "cm_mblk.x"       /* Common memory allocation */
 #include "cm_llist.x"      /* Common link list */
 #include "cm_hash.x"       /* Common hashlist */
@@ -62,11 +62,13 @@ extern "C" {
 #include "hit.h"
 #include "sct.h"
 /* header include files related to lower layer interfaces */
+
 #include "szt.h"           /* S1AP RRM control Interface */
 #include "szt_asn.h"
 #include "nb_lnb.h"
 #include "egt.h"           /* DATA app, GTP interface   */
 #include "nbu.h"
+
 #ifdef SZTV3
 #include "szt_3gasn.h"
 #endif
@@ -86,7 +88,6 @@ extern "C" {
 #include "egt.x"           /* DATA app, GTP interface   */
 #include "nbu.x"
 #include "ss_diag.h"
-
 
 #define NB_MAX_HASH_SIZE        1024
 #if (defined(NB_DBG_CIRLOG) || defined(SS_SEGV_SIG_HDLR))
@@ -483,9 +484,9 @@ typedef struct _dropRA {
   Bool isDropRA;
 } DropRA;
 
-typedef struct _sendErrorInd {
-  Bool isSendErrorInd;
-} SendErrorInd;
+typedef struct _dropErabSetupReq {
+  Bool isDropErabSetupReq;
+} DropErabSetupReq;
 
 typedef struct _nbRouterSolicitCb {
 #define NB_EGTP_MSG_SZ 1024
@@ -539,7 +540,7 @@ typedef struct _nbCb
    DelayErabSetupRsp         delayErabSetupRsp[NB_MAX_UE_SUPPORTED];
    DropRA                       dropRA[NB_MAX_UE_SUPPORTED];
    NbRouterSolicitCb            *rsCb[NB_MAX_UE_SUPPORTED];
-   SendErrorInd              sendErrorInd[NB_MAX_UE_SUPPORTED];
+   DropErabSetupReq          dropErabSetupReq[NB_MAX_UE_SUPPORTED];
 #ifdef MULTI_ENB_SUPPORT
    Bool                      x2HoDone;
 #endif

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -3731,13 +3731,11 @@ PUBLIC S16  NbBuildAndSndErrIndMsg(NbErrIndMsg *s1ErrInd)
       RETVALUE(RFAILED);
    }
 
-   NB_LOG_ERROR(&nbCb, "In NbBuildAndSndErrIndMsg");
    if (nbFillErrIndMsg(s1ErrInd,&(uDatEvnt.pdu)) != ROK)
    {
       RETVALUE(RFAILED);
    }
 
-   NB_LOG_ERROR(&nbCb, "Filled ErrIndMsg");
    uDatEvnt.transId.pres = PRSNT_NODEF;
    uDatEvnt.transId.val = 1;
    uDatEvnt.peerId.pres = PRSNT_NODEF;

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -54,7 +54,7 @@ EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 EXTERN S16 NbUiNbuHdlUeIpInfoRej(Pst *, NbuUeIpInfoRej *);
 EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp  *);
 EXTERN S16 NbEnbDropRA(NbDropRA *);
-EXTERN S16 NbEnbSendErrorInd(NbSendErrorInd*);
+EXTERN S16 NbHandleDropErabSetupReq(NbDropErabSetupReq  *);
 
 int atoi(const char *nptr);
 
@@ -268,10 +268,10 @@ PUBLIC S16 NbUiNbtMsgReq
         break;
       }
 
-      case NB_SEND_ERROR_IND: {
-        if(ROK != NbEnbSendErrorInd(&req->t.dropInitCtxtSetup)) {
-          NB_LOG_ERROR(&nbCb, "Failed to process SEND_ERROR_IND"\
-                       "from TFW");
+      case NB_DROP_ERAB_SETUP_REQ: {
+        if(ROK != NbHandleDropErabSetupReq(&req->t.dropErabSetupReq)) {
+          NB_LOG_ERROR(&nbCb, "Failed to process Drop Erab Setup Rsp "\
+                     "from TFW");
         }
         break;
       }

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -270,7 +270,7 @@ PUBLIC S16 NbUiNbtMsgReq
 
       case NB_DROP_ERAB_SETUP_REQ: {
         if(ROK != NbHandleDropErabSetupReq(&req->t.dropErabSetupReq)) {
-          NB_LOG_ERROR(&nbCb, "Failed to process Drop Erab Setup Rsp "\
+          NB_LOG_ERROR(&nbCb, "Failed to process Drop Erab Setup Req "\
                      "from TFW");
         }
         break;

--- a/TestCntlrApp/src/enbApp/nb_ui.c
+++ b/TestCntlrApp/src/enbApp/nb_ui.c
@@ -54,6 +54,7 @@ EXTERN S16 NbMultiEnbCfgReq(NbMultiEnbConfigReq*);
 EXTERN S16 NbUiNbuHdlUeIpInfoRej(Pst *, NbuUeIpInfoRej *);
 EXTERN S16 NbEnbDelayErabSetupRsp(NbDelayErabSetupRsp  *);
 EXTERN S16 NbEnbDropRA(NbDropRA *);
+EXTERN S16 NbEnbSendErrorInd(NbSendErrorInd*);
 
 int atoi(const char *nptr);
 
@@ -263,6 +264,14 @@ PUBLIC S16 NbUiNbtMsgReq
         if (ROK != NbEnbDropRA(&req->t.dropRA)) {
           NB_LOG_ERROR(&nbCb, "Failed to process Drop RA Indication  "
                           "from TFW");
+        }
+        break;
+      }
+
+      case NB_SEND_ERROR_IND: {
+        if(ROK != NbEnbSendErrorInd(&req->t.dropInitCtxtSetup)) {
+          NB_LOG_ERROR(&nbCb, "Failed to process SEND_ERROR_IND"\
+                       "from TFW");
         }
         break;
       }

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -58,6 +58,7 @@ typedef enum _nbMsgTypes
    NB_NW_INITIATED_ASSOC_DOWN,
    NB_DELAY_ERAB_SETUP_RSP,
    NB_DROP_RA,
+   NB_SEND_ERR_IND,
    NB_UNKNOWN_MSG_TYPE
 }NbMsgTypes;
 
@@ -453,6 +454,11 @@ typedef struct _nbDropRA {
   Bool isDropRA;
 } NbDropRA;
 
+typedef struct _nbSendErrorInd{
+  U32 ueId;
+  Bool isSendErrorInd;
+} NbSendErrorInd;
+
 typedef struct _nbtMsg
 {
    NbMsgTypes msgType;
@@ -488,6 +494,7 @@ typedef struct _nbtMsg
       NbMmeConfigTrnsf    mmeConfigTrnsf;
       NbDelayErabSetupRsp delayErabSetupRsp;
       NbDropRA dropRA;
+      NbSendErrorInd sendErrorInd;
    }t;
 }NbtMsg;
 

--- a/TestCntlrApp/src/fw_cm/nbt.x
+++ b/TestCntlrApp/src/fw_cm/nbt.x
@@ -58,7 +58,7 @@ typedef enum _nbMsgTypes
    NB_NW_INITIATED_ASSOC_DOWN,
    NB_DELAY_ERAB_SETUP_RSP,
    NB_DROP_RA,
-   NB_SEND_ERR_IND,
+   NB_DROP_ERAB_SETUP_REQ,
    NB_UNKNOWN_MSG_TYPE
 }NbMsgTypes;
 
@@ -288,6 +288,7 @@ typedef struct _nbErrIndMsg
 {
    U8          isUeAssoc;
    U32         ue_Id;
+   U32         enbId;
    U8          causePres;
    FailCause   cause;
    NbCriticalityDiag criticalityDiag;
@@ -454,10 +455,10 @@ typedef struct _nbDropRA {
   Bool isDropRA;
 } NbDropRA;
 
-typedef struct _nbSendErrorInd{
+typedef struct _nbDropErabSetupReq {
   U32 ueId;
-  Bool isSendErrorInd;
-} NbSendErrorInd;
+  Bool isDropErabSetupReqEnable;
+} NbDropErabSetupReq;
 
 typedef struct _nbtMsg
 {
@@ -494,7 +495,7 @@ typedef struct _nbtMsg
       NbMmeConfigTrnsf    mmeConfigTrnsf;
       NbDelayErabSetupRsp delayErabSetupRsp;
       NbDropRA dropRA;
-      NbSendErrorInd sendErrorInd;
+      NbDropErabSetupReq dropErabSetupReq;
    }t;
 }NbtMsg;
 

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -2445,7 +2445,7 @@ PUBLIC S16 tfwApi
         if (fwCb->nbState == ENB_IS_UP) {
           handleDropErabSetupReq((DropErabSetupReq_t *)msg);
         } else {
-          FW_LOG_ERROR(fwCb, "Failed to process ERAB Setup Rsp delay request:ENBAPP IS NOT UP");
+          FW_LOG_ERROR(fwCb, "Failed to process UE_DROP_ERAB_SETUP_REQ:ENBAPP IS NOT UP");
           ret = RFAILED;
         }
         break;
@@ -2589,12 +2589,10 @@ PRIVATE S16 handlErrIndMsg(fwNbErrIndMsg_t *data)
    /* copying all optional feilds */
    msgReq->msgType = NB_ERR_IND_MSG;
    msgReq->t.s1ErrIndMsg.isUeAssoc = data->isUeAssoc;
-
    if(data->isUeAssoc == TRUE)
    {
       msgReq->t.s1ErrIndMsg.ue_Id = data->ue_Id;
    }
-
 #ifdef MULTI_ENB_SUPPORT
    msgReq->t.s1ErrIndMsg.enbId = data->enbId;
 #endif

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -127,7 +127,8 @@ typedef enum {
    UE_STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT,
    UE_SET_DELAY_ERAB_SETUP_RSP,
    UE_ROUTER_ADV_IND,
-   UE_SET_DROP_ROUTER_ADV
+   UE_SET_DROP_ROUTER_ADV,
+   NB_SEND_ERROR_IND,
 }tfwCmd;
 
 typedef enum
@@ -1339,6 +1340,12 @@ typedef struct ueDropInitCtxtSetup
    Bool flag;
    U32 tmrVal;
 }UeDropInitCtxtSetup;
+
+typedef struct nbSendErrInd {
+  U32 ue_Id;
+  Bool flag;
+} NbSendErrInd;
+
 typedef struct ueDelayInitCtxtSetupRsp
 {
    U32 ue_Id;

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -128,7 +128,7 @@ typedef enum {
    UE_SET_DELAY_ERAB_SETUP_RSP,
    UE_ROUTER_ADV_IND,
    UE_SET_DROP_ROUTER_ADV,
-   NB_SEND_ERROR_IND,
+   DROP_ERAB_SETUP_REQ
 }tfwCmd;
 
 typedef enum
@@ -992,6 +992,7 @@ typedef struct fwNbErrIndMsg
 {
    U8   isUeAssoc;
    U32  ue_Id;
+   U32 enbId;
    ErrCause cause;
    FwCriticalityDiag criticalityDiag;
 }fwNbErrIndMsg_t;
@@ -1341,10 +1342,10 @@ typedef struct ueDropInitCtxtSetup
    U32 tmrVal;
 }UeDropInitCtxtSetup;
 
-typedef struct nbSendErrInd {
+typedef struct dropErabSetupReq {
   U32 ue_Id;
   Bool flag;
-} NbSendErrInd;
+} DropErabSetupReq_t;
 
 typedef struct ueDelayInitCtxtSetupRsp
 {


### PR DESCRIPTION
## Title
[error_ind_support] support to drop erab setup request

## Summary
This PR has support to drop erab-setup-request message received from mme in order to simulate sending of error indication message

## Test plan
- Tested test_send_error_ind_for_dl_nas_with_auth_req.py and test_send_error_ind_for_erab_setup_req.py in magma PR https://github.com/magma/magma/pull/6338
- Verified sanity
