### PR TITLE
[s1sim][lte] Add macros for esm cause values

### DIFF
--- a/TestCntlrApp/src/tfwApp/fw_api_int.h
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.h
@@ -65,6 +65,11 @@ extern "C" {
 #define TFW_EMM_CAUSE_INV_MSG_IN_PROT_STATE           0x65
 #define TFW_EMM_CAUSE_PROT_ERR_UNSP                   0x6f
 
+/* ESM Cause Values */
+#define TFW_ESM_CAUSE_MULTIPLE_PDN_CON_FOR_A_GIVEN_APN_NA   0x37
+#define TFW_ESM_CAUSE_MISSING_OR_UNKNOWN_APN   0x1B
+#define TFW_ESM_CAUSE_UNKNOWN_PDN_TYPE   0x1C
+
 /* SCTP ABORT Cause/Reason : RFC4960, Section 3.3.10/3.3.10.12 */
 /* The upper layer can specify this cause. SCTP transports it transparently.
  * The receiving SCTP entity may deliver it to upper layer protocol. */


### PR DESCRIPTION
## Title
[s1sim][lte] Macros for esm cause values

## Summary
Added macros for missing esm cause which are used in s1sim TCs to verify if a reject message is received with appropriate cause values

## Test plan
- Verified sanity
- Verified TCs updated in magma PR https://github.com/magma/magma/pull/6407
