### PR TITLE
Fixes Stub Compilation Errors and Update Documentation for Running Binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ $ make
 On successful compilation, the “libtrfgen.so” library gets generated under
 Trfgen/lib folder.
 
+## Compiling the Test Controller Stub Binary
+
+Once the necessary lib files i.e. `libtrfgen.so` and `libtfw.so` are built.
+Copy the files to `/usr/lib` and run `sudo ldconfig` if necessary. This is 
+necessary to execute the `testCntrlr` binary which can be built as follows:
+
+```
+$ cd TestCntlrStub/build
+$ make clean
+$ make
+```
+
+On successful build, the binary `testCntrlr` would be available at `TestCntlrStub/bin/`
+
+If you choose to not copy the generated `lib` files to `/usr/lib`, export the paths
+into the `LD_LIBRARY_PATH` as follows by replacing the `/path/to/` with the full path
+as necessary.
+
+```
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/S1APTester/TestCntlrApp/lib/:/path/to/S1APTester/Trfgen/lib
+```
+
 # Testing with Magma
 Following points should be considered when using S1APTester with
 [Magma](https://github.com/facebookincubator/magma)

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -1467,6 +1467,7 @@ typedef struct _PartialReset
 {
    U32 numOfConn;
    UeS1apIdPair *ueS1apIdPairList;
+   U32 *ueIdLst;
 }PartialReset;
 
 typedef struct _cause


### PR DESCRIPTION
This PR contains two commits. The first commit focuses on fixing a compilation error because of missing `ueIdLst`
The second commit focuses on updating the documentation to build the Controller Stub binaries for running tests.