### PR TITLE
Added code to drop activate default bearer context request

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -211,6 +211,7 @@ typedef enum _ueMsgTypes
    UE_AUTH_FAILURE_TYPE,
    UE_ICMPV6_ROUTER_ADV_TYPE,
    UE_STANDALONE_DEFAULT_EPS_BER_REJ,
+   UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ,
 }UeMsgTypes;
 
 typedef struct _ueEmmEpsAtchType
@@ -833,6 +834,11 @@ typedef struct ueEsmActDfltBearCtxtRej
 #endif
 }UeEsmActDfltBearCtxtRej;
 
+typedef struct ueDropActDfltEpsBearCtxtReq {
+  U32 ueId;
+  Bool dropActDfltEpsBearCtxtReq;
+} UeDropActDfltEpsBearCtxtReq;
+
 typedef struct _ueUetEmmInformation
 {
    U32 ueId;
@@ -955,6 +961,7 @@ typedef struct _uetMessage
      UeUetErabSetupFailedTosetup ueErabsFailedToSetup;
      UeUetAuthFailure ueUetAuthFailure;
      UeUetRouterAdv ueUetRouterAdv;
+     UeDropActDfltEpsBearCtxtReq ueDropActDfltBerReq;
    }msg;
 }UetMessage;
 /* Ue Interface general Structure declerations */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -110,9 +110,9 @@ PUBLIC S16
 handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data);
 PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp *data);
 PRIVATE Void handleDropRouterAdv(UeDropRA *data);
+PRIVATE Void handleDropErabSetupReq(DropErabSetupReq_t *data);
 PRIVATE S16
 handleEnableOrDisableActvDfltBerReq(UeDropActvDefaultEpsBearCtxtReq_t *data);
-PRIVATE Void handleDropErabSetupReq(DropErabSetupReq_t *data);
 PUBLIC FwCb gfwCb;
 
 /* Adding UEID, epsupdate type, active flag into linked list for
@@ -2442,13 +2442,6 @@ PUBLIC S16 tfwApi
          }
          break;
       }
-<<<<<<< HEAD
-      case UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ: {
-        FW_LOG_DEBUG(fwCb, "Process Enable or Disable the Drop of "
-                           "ACTV_DEFAULT_EPS_BEARER_CTXT_REQ \n");
-        handleEnableOrDisableActvDfltBerReq(
-            (UeDropActvDefaultEpsBearCtxtReq_t *)msg);
-=======
       case DROP_ERAB_SETUP_REQ: {
         FW_LOG_DEBUG(fwCb, "Process UE_DROP_ERAB_SETUP_REQ ");
         if (fwCb->nbState == ENB_IS_UP) {
@@ -2457,7 +2450,13 @@ PUBLIC S16 tfwApi
           FW_LOG_ERROR(fwCb, "Failed to process UE_DROP_ERAB_SETUP_REQ:ENBAPP IS NOT UP");
           ret = RFAILED;
         }
->>>>>>> upstream/master
+        break;
+      }
+      case UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ: {
+        FW_LOG_DEBUG(fwCb, "Process Enable or Disable the Drop of "
+                           "ACTV_DEFAULT_EPS_BEARER_CTXT_REQ \n");
+        handleEnableOrDisableActvDfltBerReq(
+            (UeDropActvDefaultEpsBearCtxtReq_t *)msg);
         break;
       }
 
@@ -3482,14 +3481,6 @@ PRIVATE Void handleDropRouterAdv(UeDropRA *data) {
   fwSendToNbApp(msgReq);
   RETVOID;
 }
-<<<<<<< HEAD
-/*
- *
- *   Fun:   handleEnableOrDisableActvDfltBerReq
- *
- *   Desc:  This function is used to enable or disable the drop of Activate
- *          Default Eps Bearer context request message from Test Controller
-=======
 
 /*
  *
@@ -3497,7 +3488,6 @@ PRIVATE Void handleDropRouterAdv(UeDropRA *data) {
  *
  *   Desc:  This function is used to process Delay Erab Setup Response
  *          message received from the test script
->>>>>>> upstream/master
  *
  *   Ret:   None
  *
@@ -3506,27 +3496,6 @@ PRIVATE Void handleDropRouterAdv(UeDropRA *data) {
  *   File:  fw_api_int.c
  *
  */
-<<<<<<< HEAD
-PUBLIC S16
-handleEnableOrDisableActvDfltBerReq(UeDropActvDefaultEpsBearCtxtReq_t *data) {
-  FwCb *fwCb = NULLP;
-  UetMessage *uetMsg = NULLP;
-  UeDropActDfltEpsBearCtxtReq *ueDropActDfltEpsBearCtxtReq = NULLP;
-  FW_GET_CB(fwCb);
-  FW_LOG_ENTERFN(fwCb);
-
-  FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
-  uetMsg->msgType = UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ;
-  ueDropActDfltEpsBearCtxtReq = &uetMsg->msg.ueDropActDfltBerReq;
-
-  ueDropActDfltEpsBearCtxtReq->ueId = data->ue_id;
-  ueDropActDfltEpsBearCtxtReq->dropActDfltEpsBearCtxtReq =
-      data->dropActDfltEpsBearCtxtReq;
-  fwSendToUeApp(uetMsg);
-  FW_LOG_EXITFN(fwCb, ROK);
-}
-
-=======
 PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp *data) {
   FwCb *fwCb = NULLP;
   NbtRequest *msgReq = NULLP;
@@ -3564,7 +3533,6 @@ PRIVATE Void handleDelayErabSetupRsp(UeDelayErabSetupRsp *data) {
  *   File:  fw_api_int.c
  *
  */
-
 PRIVATE Void handleDropErabSetupReq(DropErabSetupReq_t * data) {
   FwCb *fwCb = NULLP;
   NbtRequest *msgReq = NULLP;
@@ -3586,4 +3554,37 @@ PRIVATE Void handleDropErabSetupReq(DropErabSetupReq_t * data) {
   fwSendToNbApp(msgReq);
   RETVOID;
 }
->>>>>>> upstream/master
+
+/*
+ *
+ *   Fun:   handleEnableOrDisableActvDfltBerReq
+ *
+ *   Desc:  This function is used to enable or disable the drop of Activate
+ *          Default Eps Bearer context request message from Test Controller
+ *
+ *   Ret:   None
+ *
+ *   Notes: None
+ *
+ *   File:  fw_api_int.c
+ *
+ */
+PUBLIC S16
+handleEnableOrDisableActvDfltBerReq(UeDropActvDefaultEpsBearCtxtReq_t *data) {
+  FwCb *fwCb = NULLP;
+  UetMessage *uetMsg = NULLP;
+  UeDropActDfltEpsBearCtxtReq *ueDropActDfltEpsBearCtxtReq = NULLP;
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
+
+  FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+  uetMsg->msgType = UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ;
+  ueDropActDfltEpsBearCtxtReq = &uetMsg->msg.ueDropActDfltBerReq;
+
+  ueDropActDfltEpsBearCtxtReq->ueId = data->ue_id;
+  ueDropActDfltEpsBearCtxtReq->dropActDfltEpsBearCtxtReq =
+      data->dropActDfltEpsBearCtxtReq;
+  fwSendToUeApp(uetMsg);
+  FW_LOG_EXITFN(fwCb, ROK);
+}
+

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -108,6 +108,8 @@ handleUeInitCtxtSetupRspFailedErabs(UeInitCtxtSetupFailedErabs *data);
 PUBLIC S16
 handleStdAloneActvDfltEpsBearerContextRej(ueActvDfltEpsBearerCtxtRej_t *data);
 PRIVATE Void handleDropRouterAdv(UeDropRA *data);
+PRIVATE S16
+handleEnableOrDisableActvDfltBerReq(UeDropActvDefaultEpsBearCtxtReq_t *data);
 PUBLIC FwCb gfwCb;
 
 /* Adding UEID, epsupdate type, active flag into linked list for
@@ -2413,6 +2415,13 @@ PUBLIC S16 tfwApi
          }
          break;
       }
+      case UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ: {
+        FW_LOG_DEBUG(fwCb, "Process Enable or Disable the Drop of "
+                           "ACTV_DEFAULT_EPS_BEARER_CTXT_REQ \n");
+        handleEnableOrDisableActvDfltBerReq(
+            (UeDropActvDefaultEpsBearCtxtReq_t *)msg);
+        break;
+      }
 
      default:
       {
@@ -3432,3 +3441,36 @@ PRIVATE Void handleDropRouterAdv(UeDropRA *data) {
   fwSendToNbApp(msgReq);
   RETVOID;
 }
+/*
+ *
+ *   Fun:   handleEnableOrDisableActvDfltBerReq
+ *
+ *   Desc:  This function is used to enable or disable the drop of Activate
+ *          Default Eps Bearer context request message from Test Controller
+ *
+ *   Ret:   None
+ *
+ *   Notes: None
+ *
+ *   File:  fw_api_int.c
+ *
+ */
+PUBLIC S16
+handleEnableOrDisableActvDfltBerReq(UeDropActvDefaultEpsBearCtxtReq_t *data) {
+  FwCb *fwCb = NULLP;
+  UetMessage *uetMsg = NULLP;
+  UeDropActDfltEpsBearCtxtReq *ueDropActDfltEpsBearCtxtReq = NULLP;
+  FW_GET_CB(fwCb);
+  FW_LOG_ENTERFN(fwCb);
+
+  FW_ALLOC_MEM(fwCb, &uetMsg, sizeof(UetMessage));
+  uetMsg->msgType = UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ;
+  ueDropActDfltEpsBearCtxtReq = &uetMsg->msg.ueDropActDfltBerReq;
+
+  ueDropActDfltEpsBearCtxtReq->ueId = data->ue_id;
+  ueDropActDfltEpsBearCtxtReq->dropActDfltEpsBearCtxtReq =
+      data->dropActDfltEpsBearCtxtReq;
+  fwSendToUeApp(uetMsg);
+  FW_LOG_EXITFN(fwCb, ROK);
+}
+

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -126,7 +126,8 @@ typedef enum {
    UE_SET_INIT_CTXT_SETUP_RSP_FAILED_ERABS,
    UE_STANDALONE_ACTV_DEFAULT_EPS_BEARER_CNTXT_REJECT,
    UE_ROUTER_ADV_IND,
-   UE_SET_DROP_ROUTER_ADV
+   UE_SET_DROP_ROUTER_ADV,
+   UE_DROP_ACTV_DEFAULT_EPS_BEARER_CTXT_REQ
 }tfwCmd;
 
 typedef enum
@@ -1265,6 +1266,11 @@ typedef struct ueDeActvBearCtxtAcc
    U32 ue_Id;
    U8 bearerId;
 }UeDeActvBearCtxtAcc_t;
+
+typedef struct ueDropActvDefaultEpsBearCtxtReq {
+  U32 ue_id;
+  Bool dropActDfltEpsBearCtxtReq;
+} UeDropActvDefaultEpsBearCtxtReq_t;
 
 typedef enum
 {

--- a/TestCntlrApp/src/ueApp/ueAppdbm.x
+++ b/TestCntlrApp/src/ueApp/ueAppdbm.x
@@ -8,18 +8,18 @@
 
 /**********************************************************************
 
-    Name:  LTE UESIM - Sample Application Module 
- 
+    Name:  LTE UESIM - Sample Application Module
+
     Type:  C include file
- 
+
     Desc:  C source code for UE Sample Application
- 
-    File:  ueAppdbm.x 
- 
-    Sid:      
- 
-    Prg:    
- 
+
+    File:  ueAppdbm.x
+
+    Sid:
+
+    Prg:
+
 **********************************************************************/
 #include "cm_llist.h"      /* cm link list */
 #include "cm_llist.x"      /* cm link list */
@@ -157,7 +157,7 @@ typedef enum ueEcmState
    UE_ECM_IDLE = 0,          /* UE ECM IDLE */
    UE_ECM_CONNECTED          /* UE ECM_CONNECTED */
 }UeEcmState;
-	
+
 typedef enum ueTransState
 {
    UE_DETACHED = 0,              /* UE Detached */
@@ -174,9 +174,9 @@ typedef struct ueAppNwId
 
 typedef struct ueAppGUMMEI
 {
-   UeAppNwId  nwId;           /* Serving Network with PLMN ID */ 
+   UeAppNwId  nwId;           /* Serving Network with PLMN ID */
    U8         mmeCode;        /* MME Code */
-   U16        mmeGrpId;       /* MME Group ID */ 
+   U16        mmeGrpId;       /* MME Group ID */
 }UeAppGUMMEI;
 
 typedef struct ueAppInfo
@@ -268,7 +268,7 @@ typedef struct _ueCb
    UeEsmCb     *esmTList[CM_ESM_MAX_BEARER_ID];
    /* BID List of ESM Cbs. BID range is 5-15 */
    UeEsmCb     *esmBList[CM_ESM_MAX_BEARER_ID];
-   U32         transIdCntr;   /* Transaction counter for sending the 
+   U32         transIdCntr;   /* Transaction counter for sending the
                                  ESM Procedural transactions. */
    U16         cellId; /* cellId */
    U32         ueId;   /* ueId */
@@ -297,15 +297,16 @@ typedef struct _ueCb
    Bool    is_actv_dflt_eps_ber_ctxt_rej;
    U8      actv_dflt_eps_bear_ctxt_reject_cause;
    U8      numPdns;
+   Bool is_drop_actv_dflt_eps_ber_ctxt_req;
 }UeCb;
 
 
 typedef struct _ueAppCb
 {
-   TskInit          init;       
+   TskInit          init;
    Pst              nbPst;
    Pst              fwPst;
-   U32              trfGenIfAddr; /* IP address of eth port connected to 
+   U32              trfGenIfAddr; /* IP address of eth port connected to
                                      traffic generator*/
    U8               NASProcGuardtimer; /* timer value */
    U32              numOfUeCfgd;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -7349,7 +7349,9 @@ PRIVATE S16 ueAppEsmHdlIncUeEvnt
                         (U8 *)&actReq->pAddr.addrInfo,
                         CM_ESM_MAX_LEN_PDN_ADDRESS);
                }
-                ret = ueSendToTfwApp(tfwMsg, &ueAppCb->fwPst);
+               if (!ueCb->is_drop_actv_dflt_eps_ber_ctxt_req) {
+                 ret = ueSendToTfwApp(tfwMsg, &ueAppCb->fwPst);
+               }
                 if (ret != ROK)
                 {
                    UE_LOG_ERROR(ueAppCb, "Sending PDN Connection Response "\

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -226,6 +226,7 @@ void ueSendErabSetupRspForFailedBearers(NbuErabsInfo *pNbuErabsInfo);
 PRIVATE S16 ueProcUeStandAloneActvDfltBerCtxtRej(UetMessage *p_ueMsg, Pst *pst);
 PRIVATE S16 ueAppBuildAndSendActDefltBerContextReject(UeCb *ueCb, U8 bearerId);
 
+PRIVATE S16 ueProcDropActDefaultEpsBerCtxtReq(UetMessage *p_ueMsg, Pst *pst);
 PRIVATE S16 ueAppGetDrb(UeCb *ueCb, U8 *drb)
 {
    U8  idx;
@@ -5544,12 +5545,18 @@ PUBLIC S16 ueUiProcessTfwMsg(UetMessage *p_ueMsg, Pst *pst)
 
         break;
       }
-      default:
-      {
-         UE_LOG_ERROR(ueAppCb, "Recieved Invalid message of type: %d",
-               p_ueMsg->msgType);
-         ret = RFAILED;
-         break;
+      case UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ: {
+        UE_LOG_DEBUG(ueAppCb,
+                     "Received UE_DROP_ACT_DEFAULT_EPS_BER_CTXT_REQ from TFW");
+        ret = ueProcDropActDefaultEpsBerCtxtReq(p_ueMsg, pst);
+        break;
+      }
+
+      default: {
+        UE_LOG_ERROR(ueAppCb, "Recieved Invalid message of type: %d",
+                     p_ueMsg->msgType);
+        ret = RFAILED;
+        break;
       }
    }
    RETVALUE(ret);
@@ -7335,6 +7342,15 @@ PRIVATE S16 ueAppEsmHdlIncUeEvnt
                   }
                   break;
                 }
+                if (ueCb->is_drop_actv_dflt_eps_ber_ctxt_req) {
+                  /* Don't respond to MME with either default bearer reject or
+                   * accept to mme */
+                  UE_LOG_DEBUG(ueAppCb,
+                               "Don't respond to Activate Default Bearer "
+                               "Context Request ");
+                  break;
+                }
+
                /* send stand-alone activate default bearer accept to mme */
                 ret = ueAppBuildAndSendActDefltBerContextAccept(ueCb,
                       ueCb->ueRabCb[drbId-1].epsBearerId);
@@ -9872,3 +9888,42 @@ PRIVATE S16 ueAppBuildAndSendActDefltBerContextReject(UeCb *ueCb, U8 bearerId) {
 
   UE_LOG_EXITFN(ueAppCb, ret);
 }
+
+/*
+ *
+ *       Fun: ueProcDropActDefaultEpsBerCtxtReq
+ *
+ *       Desc:
+ *
+ *       Ret:  ROK - ok; RFAILED - failed
+ *
+ *       Notes: none
+ *
+ *       File:  ue_app.c
+ *
+ */
+PRIVATE S16 ueProcDropActDefaultEpsBerCtxtReq(UetMessage *p_ueMsg, Pst *pst) {
+  S16 ret = ROK;
+  U32 ueId;
+  UeAppCb *ueAppCb = NULLP;
+  UeCb *ueCb = NULLP;
+
+  UE_GET_CB(ueAppCb);
+  UE_LOG_ENTERFN(ueAppCb);
+  UE_LOG_DEBUG(
+      ueAppCb,
+      "Received an indication from TFWAPP to drop activate default EPS bearer "
+      "context request message \n");
+
+  ueId = p_ueMsg->msg.ueDropActDfltBerReq.ueId;
+  ret = ueDbmFetchUe(ueId, (PTR *)&ueCb);
+  if (ret != ROK) {
+    UE_LOG_ERROR(ueAppCb, "UeCb List NULL ueId = %d", ueId);
+    RETVALUE(ret);
+  }
+  ueCb->is_drop_actv_dflt_eps_ber_ctxt_req =
+      p_ueMsg->msg.ueDropActDfltBerReq.dropActDfltEpsBearCtxtReq;
+
+  UE_LOG_EXITFN(ueAppCb, ret);
+}
+


### PR DESCRIPTION
## Title
Added code to drop activate default bearer context request
## Summary
As part secondary PDN connection, mme sends activate default eps bearer context request and starts 3485 timer. 
On 3485 timer expiry, mme re-transmits activate default eps bearer context request. 
At s1ap, on reception of activate default eps bearer context request, s1ap sends activate default eps bearer context accept.
But now we intend to test 3485 timer expiry with mme restart, in which case s1ap should not send the response message. 
Later after mme has recovered, mme re-trasmits the activate default eps bearer context request for which s1ap has to respond.
To guard whether s1ap should send activate default eps bearer context accept message or not, I added code to send an indication from TFW to indicate that s1ap should not send response message or not.

These changes are required for testing test case, test_3485_timer_for_default_bearer_with_mme_restart.py

## Test plan
- Build sanity:
     Executed s1ap sanity test suite on PR, https://github.com/magma/magma/pull/5954 in which sending re-transmitted messages are handled.

- Newly added tests: 
     test_3485_timer_for_default_bearer_with_mme_restart.py and is available in PR, https://github.com/magma/magma/pull/3970
