### PR TITLE
Support to configure GUTI from testscript

### DIFF
--- a/TestCntlrApp/src/fw_cm/uet.x
+++ b/TestCntlrApp/src/fw_cm/uet.x
@@ -315,6 +315,8 @@ PDN APN */
    U8 useOldSecCtxt;
    U32 pdnType;
    UeEmmEpsAtchType epsAtchType;
+   Bool gutiMI_pres;
+   Guti gutiMI;
    Guti oldGuti;
    U8 imsi_len;
    U8 imsi[15];

--- a/TestCntlrApp/src/tfwApp/fw_api_int.c
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.c
@@ -824,6 +824,13 @@ PUBLIC S16 handleAttachReq(ueAttachRequest_t *data)
    if ((data->mIdType == CM_EMM_MID_TYPE_IMSI) && (data->imsi_len > 0)) {
      cmMemcpy(ueAttachReq->imsi, data->imsi, data->imsi_len);
      ueAttachReq->imsi_len = data->imsi_len;
+   } else if ((data->mIdType == CM_EMM_MID_TYPE_GUTI) && (data->guti_mi.pres == TRUE)) {
+      ueAttachReq->gutiMI_pres = TRUE;
+      cmMemcpy(ueAttachReq->gutiMI.mcc, data->guti_mi.guti.mcc, 3);
+      cmMemcpy(ueAttachReq->gutiMI.mnc, data->guti_mi.guti.mnc, 3);
+      ueAttachReq->gutiMI.mmeGrpId = data->guti_mi.guti.mmeGrdId;
+      ueAttachReq->gutiMI.mmeCode = data->guti_mi.guti.mmeCode;
+      ueAttachReq->gutiMI.mTMSI = data->guti_mi.guti.mTmsi;
    }
 
    /* optional feilds */

--- a/TestCntlrApp/src/tfwApp/fw_api_int.x
+++ b/TestCntlrApp/src/tfwApp/fw_api_int.x
@@ -724,6 +724,7 @@ typedef struct ueAttachRequest
    U8 imsi_len;
    U8 imsi[25];
    guti guti_pr;
+   guti guti_mi;
    last_TAI lastTAI_pr;
    pdn_Type pdnType_pr;
    pdn_APN pdnAPN_pr;

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1229,7 +1229,7 @@ PRIVATE S16 ueAppUtlBldAttachReq(UeCb *ueCb, CmNasEvnt **ueEvt,
       attachReq->epsMi.evenOddInd = UE_EVEN;
       attachReq->epsMi.len = sizeof(GUTI);
       if (ueUetAttachReq.gutiMI_pres) {
-        UE_LOG_DEBUG(ueAppCb, "Filling user provided MI GUTI from testscript");
+        UE_LOG_DEBUG(ueAppCb, "Filling MI GUTI received from testscript");
         cmMemcpy((U8 *)&attachReq->epsMi.u.guti, (U8 *)&ueUetAttachReq.gutiMI,
                attachReq->epsMi.len);
       } else {

--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -1228,8 +1228,14 @@ PRIVATE S16 ueAppUtlBldAttachReq(UeCb *ueCb, CmNasEvnt **ueEvt,
       attachReq->epsMi.type = CM_EMM_MID_TYPE_GUTI;
       attachReq->epsMi.evenOddInd = UE_EVEN;
       attachReq->epsMi.len = sizeof(GUTI);
-      cmMemcpy((U8 *)&attachReq->epsMi.u.guti, (U8 *)&ueCb->ueCtxt.ueGuti,
+      if (ueUetAttachReq.gutiMI_pres) {
+        UE_LOG_DEBUG(ueAppCb, "Filling user provided MI GUTI from testscript");
+        cmMemcpy((U8 *)&attachReq->epsMi.u.guti, (U8 *)&ueUetAttachReq.gutiMI,
                attachReq->epsMi.len);
+      } else {
+        cmMemcpy((U8 *)&attachReq->epsMi.u.guti, (U8 *)&ueCb->ueCtxt.ueGuti,
+               attachReq->epsMi.len);
+      }
       break;
     }
     case CM_EMM_MID_TYPE_IMEI: {


### PR DESCRIPTION
Support to configure GUTI from test script

## Summary
This PR supports configuration of GUTI value from the test script. 
ueApp reads GUTI provided from the test script if available. Otherwise it reads the value stored in ueContext.

## Test plan
- Verified new TC in PR- https://github.com/magma/magma/pull/7918
- Verified complete sanity suite 