### PR TITLE
fix(agw): Fixed s1 ue context release issue

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -1947,8 +1947,13 @@ PUBLIC Void nbDamUeDelReq
       /* If the number of DRBs become zero remove the UeCb */
       if (ueCb->numDrbs == 0)
       {
-         nbDamDelUe(ueId);
-         RETVOID;
+        if (ROK != nbDamDelUe(ueId)) {
+          NB_LOG_ERROR(&nbCb, "Failed to delete ENB Dam UE for UE Id: %u", ueId);
+          RETVOID;
+        }
+        pst = &nbDamCb.nbAppPst;
+        cmPkUeDelCfm(pst, ueId);
+        RETVOID;
       }
       for(;!isEmpty && ((cmHashListGetNext(&(ueCb->drbs),(PTR)prevDrbCb,(PTR*)&drbCb)) == ROK);)
       {   

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -3432,11 +3432,8 @@ PUBLIC S16 nbCtxtRelSndRlsCmpl(NbUeCb *ueCb)
    relRsp.spConnId = ueCb->s1ConCb->spConnId;
    relRsp.pdu      = ctxtRelPdu;
 #ifdef MULTI_ENB_SUPPORT
-   for(enbIdx = 0; enbIdx < smCfgCb.numOfEnbs; enbIdx++)
-   {
-      relRsp.enbId = enbIdx;
-      NbIfmS1apRelRsp(&relRsp);
-   }
+   relRsp.enbId = ueCb->enbId;
+   NbIfmS1apRelRsp(&relRsp);
 #else
    NbIfmS1apRelRsp(&relRsp);
 #endif
@@ -4781,6 +4778,7 @@ PUBLIC S16 nbPrcPathSwReqAck
       }
    }
 
+   nbCb.x2HoDone = FALSE;
    nbUiSendPathSwReqAckToUser(nbpathSwReqAck);
    RETVALUE(ROK);
 } /* nbPrcResetAck */


### PR DESCRIPTION
## Title
Fixed s1 ue context release issue

## Summary
The X2 handover and some secondary pdn test cases were getting stuck when handling the normal detach and waiting for S1 UE context release. The S1AP tester was deleting the data module UE context whereas missing the deletion of enbapp UE context deletion causing the problem. This PR fixes the issue.

## Test plan
Verified with Sanity and individual test case execution.
