### PR TITLE
fix(agw): Fixed invalid timer error

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_tmr.c
+++ b/TestCntlrApp/src/enbApp/nb_tmr.c
@@ -446,7 +446,7 @@ S16                          event
  *         Processing steps:
  *               Check Whetether Timer is running or not based on Event type
  *
- * @param[in] tmr : pointre to the Timer.
+ * @param[in] tmr : pointer to the Timer.
  * @param[in] event : One of the many possible timer types.
  * @return S16
  *        -# Success : ROK


### PR DESCRIPTION
## Title
Fixed invalid timer error

## Summary
The test case execution with Magma was leaving invalid timer event handling errors. The issue was that there were many timers which were initialized by default timer structures and hence setting to default zero timer event value. However the timer event value was set to invalid only when we were stopping the timers. While checking for timers we were checking the invalid timers only and not the default timer values. This was leading to invalid timer error even though the timer was a valid one. This PR fixes the issue.

## Test plan
Verified with Sanity.

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>