### PR TITLE
fix(agw): Corrected message name in log

### DIFF
--- a/TestCntlrApp/src/ueApp/ue_app.c
+++ b/TestCntlrApp/src/ueApp/ue_app.c
@@ -9382,7 +9382,7 @@ PRIVATE S16 ueBldEmmInformationToTfw(UetMessage *tfwMsg, UeCb *ueCb)
    UE_GET_CB(ueAppCb);
    UE_LOG_ENTERFN(ueAppCb);
 
-   UE_LOG_DEBUG(ueAppCb, "Building Detach Accept Indication to TFWAPP");
+   UE_LOG_DEBUG(ueAppCb, "Building EMM Information Indication to TFWAPP");
    tfwMsg->msgType = UE_EMM_INFORMATION_TYPE;
    tfwMsg->msg.ueEmmInformation.ueId = ueCb->ueId;
 


### PR DESCRIPTION
## Title
Corrected S1AP message name in S1APTester log

## Summary
EMM Information indication was wrongly marked as detach accept message, giving false impression of detach procedure. This PR corrects the message name to be printed in the log.

## Test plan
Verified with sanity and individual test cases
