### PR TITLE
Modified code to release the UE for which eNB reset message is triggered

### DIFF
--- a/TestCntlrApp/src/cm/szt.x
+++ b/TestCntlrApp/src/cm/szt.x
@@ -136,6 +136,7 @@ typedef struct sztUDatEvnt
    TknU32               transId;       /* Transaction Id */
    TknU32               peerId;        /* Peer Identifier */
    S1apPdu              *pdu;          /* S1AP event structure */ 
+   UConnId              spConnId;      /* service provider instance identifier */
 /* Multi eNB support */
 #ifdef MULTI_ENB_SUPPORT
    U32 enbId;

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -889,6 +889,7 @@ PUBLIC S16 NbEnbResetReqHdl
 {
    U32 idx = 0;
    S16 ret = ROK;
+   UConnId spConnId = 0;
    NbUeCb *ueCb = NULLP, *prev = NULLP;
    NbResetMsgInfo resetMsgInfo = {0};
    NB_LOG_ENTERFN(&nbCb);
@@ -933,7 +934,9 @@ PUBLIC S16 NbEnbResetReqHdl
    {
       while (cmHashListGetNext(&(nbCb.ueCbLst), (PTR)prev, (PTR *)&ueCb) == ROK)
       {
+	  if (ueCb->enbId ==  resetReq->u.completeRst.enbId) {
          NB_LOG_DEBUG(&nbCb, "Found ueCb->ueId=%d in HashList", ueCb->ueId);
+	 spConnId = ueCb->s1ConCb->spConnId;
          /* Inform the UeApp about UE context release */
          NB_LOG_DEBUG(&nbCb, "Inform UE to release context");
          ret = nbSendS1RelIndToUeApp(ueCb->ueId);
@@ -953,12 +956,16 @@ PUBLIC S16 NbEnbResetReqHdl
          prev = NULLP;
          /* Delete hash list entry for ueCb */
          cmHashListDelete(&(nbCb.ueCbLst), (PTR)ueCb);
+	 break;
+	  } else {
+         prev = ueCb;
+	  }
       }
 #ifdef MULTI_ENB_SUPPORT
    resetMsgInfo.enbId = resetReq->u.completeRst.enbId;
 #endif
    }
-   if(nbBuildAndSendResetRequest(&resetMsgInfo) != ROK)
+   if(nbBuildAndSendResetRequest(&resetMsgInfo, spConnId) != ROK)
    {
       NB_LOG_ERROR(&nbCb,"Failed to send Reset request");
       NB_FREE(resetMsgInfo.enbUeS1apIdLst, sizeof(U32) * resetMsgInfo.s1apIdCnt);

--- a/TestCntlrApp/src/enbApp/nb.h
+++ b/TestCntlrApp/src/enbApp/nb.h
@@ -778,7 +778,7 @@ EXTERN S16 nbSendS1RelIndToUeApp(U32 ueId);
 
 EXTERN S16 nbBuildAndSendS1SetupReq(NbMmeId mmeId);
 
-EXTERN S16 nbBuildAndSendResetRequest(NbResetMsgInfo *resetMsgInfo);
+EXTERN S16 nbBuildAndSendResetRequest(NbResetMsgInfo *resetMsgInfo, UConnId spConnId);
 
 EXTERN S16 nbBuildAndSendErabRelInd(U32 enbUeS1apId, U32 mmeUeS1apId,
       U8 numOfErabIds, U8 *erabIdLst);

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -192,7 +192,7 @@ PUBLIC S16 nbBuildAndSendS1SetupReq
 
 PUBLIC S16 nbBuildAndSendResetRequest
 (
- NbResetMsgInfo *resetMsgInfo
+ NbResetMsgInfo *resetMsgInfo, UConnId spConnId
 )
 {
    SztUDatEvnt uDatEvnt;
@@ -213,6 +213,7 @@ PUBLIC S16 nbBuildAndSendResetRequest
    uDatEvnt.transId.val = 1;
    uDatEvnt.peerId.pres = PRSNT_NODEF;
    uDatEvnt.peerId.val = nbCb.mmeInfo.mmeId;
+   uDatEvnt.spConnId = spConnId;
 #ifdef MULTI_ENB_SUPPORT
    uDatEvnt.enbId = resetMsgInfo->enbId;
 #endif

--- a/TestCntlrApp/src/s1ap/sz.x
+++ b/TestCntlrApp/src/s1ap/sz.x
@@ -293,7 +293,7 @@ EXTERN SzCb  szCb;
 typedef S16 (*PFRAM) ARGS((SzConCb *conCb, SzPeerCb *peerCb, S1apPdu *pdu));
 typedef S16 (*PFSZLIMSGHANDLER) ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 typedef S16 (*PFSZMGMTUIMSGHANDLER) ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                          SzSztSapCb *uSapCb, U8 *cause));
+                                          SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 
 /**********************************************************************
  Externs
@@ -454,7 +454,7 @@ EXTERN S16 szUbndSztSap ARGS((SpId uSapId, U8 opn));
 
 #ifdef SZ_ENB
 EXTERN S16 szMgmtUiSetupReq     ARGS((SzPeerCb *peerCb, S1apPdu *pdu, 
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtLiPaging       ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 EXTERN S16 szMgmtLiSetupRsp     ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 EXTERN S16 szMgmtLiSetupFailure ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
@@ -475,17 +475,17 @@ EXTERN S16 szMgmtLiEnbDirTrans  ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 #endif
 
 EXTERN S16 szMgmtUiInvldMsgHandler ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtUiMsgHandler   ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtUiRst          ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtUiRstAck       ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtLiRst          ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 EXTERN S16 szMgmtLiRstAck       ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 EXTERN S16 szMgmtUiErrInd       ARGS((SzPeerCb *peerCb, S1apPdu *pdu,
-                                      SzSztSapCb *uSapCb, U8 *cause));
+                                      SzSztSapCb *uSapCb, U8 *cause, UConnId suConnId));
 EXTERN S16 szMgmtLiErrInd       ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 EXTERN S16 szMgmtLiMsgHandler   ARGS((SzPeerCb *peerCb, S1apPdu *pdu));
 

--- a/TestCntlrApp/src/s1ap/sz_mgmt.c
+++ b/TestCntlrApp/src/s1ap/sz_mgmt.c
@@ -256,14 +256,16 @@ PUBLIC S16 szMgmtUiInvldMsgHandler
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */
+U8          *cause,                    /* Error cause */
+UConnId suConnId
 )
 #else
-PUBLIC S16 szMgmtUiInvldMsgHandler(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiInvldMsgHandler(peerCb, pdu, uSapCb, cause, suConnId)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb  *uSapCb;                  /* SZT Sap control block */
 U8          *cause;                  /* Error cause */
+UConnId     suConnId;
 #endif
 {
    S16        ret = RFAILED;
@@ -334,14 +336,16 @@ PUBLIC S16 szMgmtUiSetupReq
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */
+U8          *cause,                    /* Error cause */
+UConnId suConnId
 )
 #else
-PUBLIC S16 szMgmtUiSetupReq(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiSetupReq(peerCb, pdu, uSapCb, cause, suConnId)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb  *uSapCb;                 /* SZT Sap control block */
 U8          *cause;                  /* Error cause */
+UConnId     suConnId;
 #endif
 {
    S16        ret = ROK;             /* return value */
@@ -588,14 +592,16 @@ PUBLIC S16 szMgmtUiMsgHandler
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */
+U8          *cause,                    /* Error cause */
+UConnId suConnId
 )
 #else
-PUBLIC S16 szMgmtUiMsgHandler(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiMsgHandler(peerCb, pdu, uSapCb, cause, suConnId)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb  *uSapCb;                 /* SZT Sap control block */
 U8          *cause;                  /* Error cause */
+UConnId     suConnId;
 #endif
 {
    S16        ret = ROK;             /* return value */ 
@@ -647,14 +653,16 @@ PUBLIC S16 szMgmtUiRst
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */
+U8          *cause,                    /* Error cause */
+UConnId lclRefNum
 )
 #else
-PUBLIC S16 szMgmtUiRst(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiRst(peerCb, pdu, uSapCb, cause, lclRefNum)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb  *uSapCb;                 /* SZT Sap control block */
-U8          *cause;                  /* Error cause */
+U8          *cause;                    /* Error cause */
+UConnId lclRefNum;
 #endif
 {
    S16         ret = ROK;             /* return value */
@@ -734,7 +742,7 @@ U8          *cause;                  /* Error cause */
          as per the choice in the reset */
       if (((SztResetTyp *)tknIE)->choice.val == SZ_FULL_RESET)
       {
-         (Void) szNdbRelConns(peerCb);
+         ret = szNdbDeallocConCb(lclRefNum, peerCb, SZ_CONN_REF_LCL);
       }
       else
       {
@@ -846,14 +854,16 @@ PUBLIC S16 szMgmtUiRstAck
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */ 
+U8          *cause,                    /* Error cause */
+UConnId suConnId
 )
 #else
-PUBLIC S16 szMgmtUiRstAck(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiRstAck(peerCb, pdu, uSapCb, cause, suConnId)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb *uSapCb;                  /* SZT Sap control block */
-U8          *cause;                  /* Error cause */
+U8          *cause;                    /* Error cause */
+UConnId suConnId;
 #endif
 {
    S16         ret = ROK;             /* return value */
@@ -1173,14 +1183,17 @@ PUBLIC S16 szMgmtUiErrInd
 SzPeerCb    *peerCb,                  /* Peer control block */
 S1apPdu     *pdu,                     /* S1AP PDU */
 SzSztSapCb  *uSapCb,                  /* SZT Sap control block */
-U8          *cause                    /* Error cause */
+U8          *cause,                    /* Error cause */
+UConnId     suConnId
 )
 #else
-PUBLIC S16 szMgmtUiErrInd(peerCb, pdu, uSapCb, cause)
+PUBLIC S16 szMgmtUiErrInd(peerCb, pdu, uSapCb, cause, suConnId)
 SzPeerCb    *peerCb;                 /* Peer control block */
 S1apPdu     *pdu;                    /* S1AP PDU */
 SzSztSapCb  *uSapCb;                  /* SZT Sap control block */
 U8          *cause;                  /* Error cause */
+UConnId      suConnId;
+
 #endif
 {
    S16        ret = ROK;             /* return value */

--- a/TestCntlrApp/src/s1ap/sz_ui.c
+++ b/TestCntlrApp/src/s1ap/sz_ui.c
@@ -516,7 +516,7 @@ SztUDatEvnt *uDatEvnt; /* connectionless sdus */
 #ifdef SZ_ENB
    if(peer->nodeType == LSZ_NODE_MME)
    {
-      ret = szMgmtUiEnb[evnt](peer, uDatEvnt->pdu, uSapCb, &cause);
+      ret = szMgmtUiEnb[evnt](peer, uDatEvnt->pdu, uSapCb, &cause, uDatEvnt->spConnId);
    }
 #endif /* SZ_ENB */
 


### PR DESCRIPTION
Signed-off-by: Rashmi <rashmi.sarwad@radisys.com>

## Title
Modified code to release the UE for which eNB reset message is triggered

## Summary
As part of fixing issue, https://github.com/magma/magma/issues/11050.  test case, test_multi_enb_complete_reset.py was failing because as part of test case, it first connects 5 eNBs and for each eNB there shall be one UE connected. 
When complete reset is initiated for one eNB; all UE contexts were getting deleted; Ideally we need to delete the contexts only for the UE for which eNB Reset is triggered. 
This issue is fixed in this PR
## Test plan
Executed s1ap sanity test suite
