### PR TITLE
Fix  ipv4v6 transport layer addresses handling in ICS Req and ERAB SETUP Req

### DIFF
--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2905,7 +2905,8 @@ PUBLIC S16 nbGetErabInfoFrmErabSetup(NbUeCb *ueCb,
             {
                /* This means both IPv4 and IPv6 addresses are present. We are */
                /* yet to support this option                                  */
-               RETVALUE(RFAILED);
+               // TODO: Add ipv4v6 support
+               break;
             }
       }
       if (ROK != cmHashListInsert(&(ueCb->tunnInfo), (PTR)tunInfo,
@@ -2996,7 +2997,6 @@ PUBLIC S16 nbGetErabInfoFrmIntCnxt
             erabItem->e_RAB_ID.val);
 #endif
       /* store the SGW IP Address */
-      printf("transportLyrAddr.len=%d\n", erabItem->transportLyrAddr.len);
       switch(erabItem->transportLyrAddr.len)
       {
          case 32:
@@ -3034,6 +3034,7 @@ PUBLIC S16 nbGetErabInfoFrmIntCnxt
             {
                /* This means both IPv4 and IPv6 addresses are present. We are */
                /* yet to support this option                                  */
+              // TODO: Add ipv4v6 support
               break;
             }
       }

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -2996,6 +2996,7 @@ PUBLIC S16 nbGetErabInfoFrmIntCnxt
             erabItem->e_RAB_ID.val);
 #endif
       /* store the SGW IP Address */
+      printf("transportLyrAddr.len=%d\n", erabItem->transportLyrAddr.len);
       switch(erabItem->transportLyrAddr.len)
       {
          case 32:
@@ -3033,7 +3034,7 @@ PUBLIC S16 nbGetErabInfoFrmIntCnxt
             {
                /* This means both IPv4 and IPv6 addresses are present. We are */
                /* yet to support this option                                  */
-               RETVALUE(RFAILED);
+              break;
             }
       }
       if (ROK != cmHashListInsert(&(ueCb->tunnInfo),(PTR)tunInfo,


### PR DESCRIPTION
## Title
Fix  ipv4v6 transport layer addresses handling in ICS Req and ERAB SETUP Req

## Summary
S1ap tester does not handle ipv4v6 transport layer addresses received in ICS request or ERAB SETUP request as of now. Fixed the issue temporarily by replacing RFAILED with break.

## Test plan
- Verified UE successfully attaches to the network by executing test_attach_detach.py TC on PR: https://github.com/magma/magma/pull/10613/

