### PR TITLE
fix(agw): Fixed wrong typecasting of UE Id

### DIFF
--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -418,7 +418,7 @@ PUBLIC S16 nbPrcDamUeDelCfm(U32 ueId)
 
    NB_LOG_ENTERFN(&nbCb);
 
-   NB_LOG_DEBUG(&nbCb,"all the bearer deleted related to ueId:[%u], deleting the uecb...\n",ueId);
+   NB_LOG_DEBUG(&nbCb,"All the bearers deleted related to ueId:[%u], deleting the uecb...\n",ueId);
    ret = nbDelUeCb(ueId);
    RETVALUE(ret);
 }

--- a/TestCntlrApp/src/enbApp/nb.c
+++ b/TestCntlrApp/src/enbApp/nb.c
@@ -418,7 +418,7 @@ PUBLIC S16 nbPrcDamUeDelCfm(U32 ueId)
 
    NB_LOG_ENTERFN(&nbCb);
 
-   NB_LOG_DEBUG(&nbCb,"all the bearer deleted related to ueId:[%d], deleting the uecb...\n",ueId);
+   NB_LOG_DEBUG(&nbCb,"all the bearer deleted related to ueId:[%u], deleting the uecb...\n",ueId);
    ret = nbDelUeCb(ueId);
    RETVALUE(ret);
 }

--- a/TestCntlrApp/src/enbApp/nb_dam.c
+++ b/TestCntlrApp/src/enbApp/nb_dam.c
@@ -37,7 +37,7 @@
 #include "tft.h"
 #include "nb_icmpv6.h"
 
-EXTERN S16 cmPkUeDelCfm(Pst*, U8);
+EXTERN S16 cmPkUeDelCfm(Pst*, U32);
 PRIVATE S16 nbDamLSapCfg(LnbMngmt *cfg, CmStatus *status);
 PRIVATE S16 nbDamLSapCntrl(LnbCntrl *sapCntrl,CmStatus *status,Elmnt elmnt);
 PRIVATE S16 nbDamBndLSap (NbLiSapCb *sapCb,CmStatus  *status,Elmnt elmnt);

--- a/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
+++ b/TestCntlrApp/src/enbApp/nb_ifm_dam_utils.c
@@ -71,7 +71,7 @@
 #define cmPkDamEgtpTeid SPkU32
 
 EXTERN S16 nbUeTnlCreatCfm(U8, U32);
-EXTERN S16 nbPrcDamUeDelCfm(U8);
+EXTERN S16 nbPrcDamUeDelCfm(U32);
 /*
   Defines for the packing and unpacking
 */

--- a/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
+++ b/TestCntlrApp/src/enbApp/nb_s1ap_hndlr.c
@@ -63,7 +63,7 @@ PRIVATE S16 nbPrcUnsuccPdu(U32, S1apPdu*);
 PRIVATE S16 nbRabSetupSndS1apRsp(NbUeCb *ueCb, NbErabLst *erabInfo,
                                  NbFailedErabLst *failedErabInfo);
 PUBLIC S16 nbS1apFillCtxtRelCmpl(NbS1ConCb *, S1apPdu **);
-S16 nbIfmDamUeDelReq(U8);
+S16 nbIfmDamUeDelReq(U32);
 PUBLIC S16 nbS1apFillCause(SztCause *ie, NbUeMsgCause *cause);
 PUBLIC S16 nbGetErabInfoFrmErabSetup(NbUeCb *, SztE_RABToBeSetupLstBrSUReq *,
                                      NbErabLst **, NbFailedErabLst **);


### PR DESCRIPTION
## Title
fix(agw): Fixed wrong typecasting of UE Id

## Summary
Typecasting of U8 is done at some places instead of U32 for UE Id while deleting the UE context in detach procedure. Because of this, UE Id was printed wrongly when attaching more than 255 UEs. This PR fixes the issue.



## Test plan
Verified with sanity
